### PR TITLE
Update RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,9 +67,6 @@ SpaceInsideHashLiteralBraces:
 TrailingCommaInArguments:
   EnforcedStyleForMultiline: no_comma
 
-TrailingCommaInLiteral:
-  EnforcedStyleForMultiline: no_comma
-
 Bundler/OrderedGems:
   Enabled: false
 
@@ -105,7 +102,7 @@ Metrics/ModuleLength:
 Naming/HeredocDelimiterNaming:
   Enabled: false
 
-Performance/HashEachMethods:
+Naming/UncommunicativeMethodParamName:
   Enabled: false
 
 Rails/ApplicationRecord:
@@ -293,6 +290,12 @@ Style/RescueStandardError:
 
 Style/Send:
   Enabled: true
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: no_comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: no_comma
 
 Style/UnneededPercentQ:
   Enabled: true

--- a/lib/generators/granite/install_controller_generator.rb
+++ b/lib/generators/granite/install_controller_generator.rb
@@ -3,7 +3,7 @@ require 'rails/generators/base'
 module Granite
   module Generators
     class InstallControllerGenerator < Rails::Generators::Base
-      source_root File.expand_path('../../../..', __FILE__)
+      source_root File.expand_path('../../..', __dir__)
 
       desc 'Creates a Granite::Controller for further customization'
 

--- a/lib/generators/granite_generator.rb
+++ b/lib/generators/granite_generator.rb
@@ -1,5 +1,5 @@
 class GraniteGenerator < Rails::Generators::NamedBase
-  source_root File.expand_path('../templates', __FILE__)
+  source_root File.expand_path('templates', __dir__)
 
   argument :projector, type: :string, required: false
   class_option :collection, type: :boolean, aliases: '-C', desc: 'Generate collection action'

--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -10,7 +10,7 @@ class GraniteApplication < Rails::Application
 end
 
 Rails.application = GraniteApplication.new
-Rails.application.paths['config/database'] << File.expand_path('../database.yml', __FILE__)
+Rails.application.paths['config/database'] << File.expand_path('database.yml', __dir__)
 Rails.application.secrets.secret_key_base = '1234567890'
 Rails.application.routes_reloader.route_sets << Rails.application.routes
 Rails.configuration.eager_load = false


### PR DESCRIPTION
My other PRs are red because RuboCop changed a few configuration files. I created this one to fix RuboCop issues.

I disabled the current `Naming/UncommunicativeMethodParamName:` since it complain against keys like `as:` and when we're shortcutting to `rescue => e` as the variable.

I can be changing it but looks like this if it's still generating some unnecessary noise.

### Review

- n/a Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
