### PR TITLE
Configure allowed names for Naming/UncommunicativeMethodParamName

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -103,7 +103,10 @@ Naming/HeredocDelimiterNaming:
   Enabled: false
 
 Naming/UncommunicativeMethodParamName:
-  Enabled: false
+  Enabled: true
+  AllowedNames:
+    - as # used in keywords arguments
+    - e  # used in exceptions
 
 Rails/ApplicationRecord:
   Enabled: true


### PR DESCRIPTION
Using`AllowedNames` instead of disabling the cop.

Follow up after merging #3.

### Review

- (n/a) Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Squash related commits together.
