### PR TITLE
Fix Granite documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or install it yourself as:
 
 ## Usage
 
-Please see [our official documentation](https://granite.toptal.net) or check the
+Please see [our official documentation](https://toptal.github.io/granite/) or check the
 [granite application example](https://github.com/toptal/example_granite_application).
 
 ### Versioning


### PR DESCRIPTION
Update the link back to https://toptal.github.io/granite/.

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
