### PR TITLE
Add .with_message to raise_validation_error matcher

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+PATH_add bin

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -55,7 +55,12 @@ end
 
 <h3 id="testing-validations">Validations</h3>
 
-Validations tests are no different to ActiveRecord models tests
+Validations tests are no different to ActiveRecord models tests.
+However, for convenience we provide `raise_validation_error`:
+
+```ruby
+specify { expect { perform! }.to raise_validation_error.on_attribute(:company).of_type(:not_approved).with_message("Company needs approval") }
+```
 
 <h3 id="testing-perform">Perform</h3>
 
@@ -64,4 +69,3 @@ Run the action using `perform!` to test side-effects:
 ```ruby
 specify { expect { perform! }.to change(User, :count).by(1) }
 ```
-

--- a/spec/lib/granite/rspec/raise_validation_error_spec.rb
+++ b/spec/lib/granite/rspec/raise_validation_error_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'raise_validation_error', aggregate_failures: false do
 
     specify do
       expect { action.perform! }.not_to raise_validation_error
+      expect { action.perform! }.not_to raise_validation_error.with_message('some message')
     end
   end
 
@@ -41,13 +42,19 @@ RSpec.describe 'raise_validation_error', aggregate_failures: false do
     specify do
       expect do
         expect { action.perform! }.to raise_validation_error.on_attribute(:raise_error)
-      end.to fail_with('expected to raise validation error on attribute :raise_error, but raised {:base=>[{:error=>:some_error}], :raise_error=>[]}')
+      end.to fail_with('expected to raise validation error on attribute :raise_error, but raised {:base=>[{:error=>:some_error}]}')
     end
 
     specify do
       expect do
         expect { action.perform! }.to raise_validation_error.on_attribute(:raise_error).of_type(:some_error)
-      end.to fail_with('expected to raise validation error on attribute :raise_error of type :some_error, but raised {:base=>[{:error=>:some_error}], :raise_error=>[]}')
+      end.to fail_with('expected to raise validation error on attribute :raise_error of type :some_error, but raised {:base=>[{:error=>:some_error}]}')
+    end
+
+    specify do
+      expect do
+        expect { action.perform! }.to raise_validation_error.with_message("Some message that does not match")
+      end.to fail_with('expected to raise validation error on attribute :base with message "Some message that does not match", but raised {:base=>[{:error=>:some_error}]}')
     end
   end
 end


### PR DESCRIPTION
Add `.with_message` chain method to `raise_validation_error`:

```
expect { some code }.to raise_validation_error.with_message("Some custom message")
```

Needed to match on error messages.

### Review

- [x] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
