### PR TITLE
Introduce `after_commit` hook for Actions

### DIFF
--- a/lib/granite/action/exceptions_handling.rb
+++ b/lib/granite/action/exceptions_handling.rb
@@ -1,0 +1,39 @@
+module Granite
+  class Action
+    module ExceptionsHandling
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :_exception_handlers, instance_writer: false
+        self._exception_handlers = {}
+
+        protected :_exception_handlers
+      end
+
+      module ClassMethods
+        # Register default handler for exceptions thrown inside execute_perform! and after_commit methods.
+        # @param klass Exception class, could be parent class too [Class]
+        # @param block [Block<Exception>] with default behavior for handling specified
+        #   type exceptions. First block argument is raised exception instance.
+        #
+        # @return [Hash<Class, Proc>] Registered handlers
+        def handle_exception(klass, &block)
+          self._exception_handlers = _exception_handlers.merge(klass => block)
+        end
+      end
+
+      private
+
+      def handled_exceptions
+        _exception_handlers.keys
+      end
+
+      def handle_exception(e)
+        klass = e.class.ancestors.detect do |ancestor|
+          ancestor <= Exception && _exception_handlers[ancestor]
+        end
+        instance_exec(e, &_exception_handlers[klass]) if klass
+      end
+    end
+  end
+end

--- a/lib/granite/action/performing.rb
+++ b/lib/granite/action/performing.rb
@@ -1,3 +1,4 @@
+require 'granite/action/exceptions_handling'
 require 'granite/action/transaction'
 require 'granite/action/error'
 
@@ -17,28 +18,14 @@ module Granite
     module Performing
       extend ActiveSupport::Concern
 
+      include ExceptionsHandling
       include Transaction
 
       included do
-        class_attribute :_exception_handlers, instance_writer: false
-        self._exception_handlers = {}
-
-        protected :_exception_handlers
-
         define_callbacks :execute_perform
       end
 
       module ClassMethods
-        # Register default handler for exceptions thrown inside execute_perform! method.
-        # @param klass Exception class, could be parent class too [Class]
-        # @param block [Block<Exception>] with default behavior for handling specified
-        #   type exceptions. First block argument is raised exception instance.
-        #
-        # @return [Hash<Class, Proc>] Registered handlers
-        def handle_exception(klass, &block)
-          self._exception_handlers = _exception_handlers.merge(klass => block)
-        end
-
         def perform(*)
           fail 'Perform block declaration was removed! Please declare `private def execute_perform!(*)` method'
         end
@@ -108,7 +95,7 @@ module Granite
         result = run_callbacks(:execute_perform) { execute_perform!(options) }
         @_action_performed = true
         result || true
-      rescue *_exception_handlers.keys => e
+      rescue *handled_exceptions => e
         handle_exception(e)
         raise_validation_error(e) if raise_errors
         raise Rollback
@@ -120,13 +107,6 @@ module Granite
 
       def execute_perform!(**_options)
         fail NotImplementedError, "BA perform body MUST be defined for #{self}"
-      end
-
-      def handle_exception(e)
-        klass = e.class.ancestors.detect do |ancestor|
-          ancestor <= Exception && _exception_handlers[ancestor]
-        end
-        instance_exec(e, &_exception_handlers[klass]) if klass
       end
     end
   end

--- a/lib/granite/action/performing.rb
+++ b/lib/granite/action/performing.rb
@@ -54,7 +54,7 @@ module Granite
       #   using `:on`)
       # @return [Object] result of execute_perform! method execution or false in case of errors
       def perform(context: nil, **options)
-        transactional do
+        transaction do
           valid?(context) && perform_action(options)
         end
       end
@@ -72,7 +72,7 @@ module Granite
       # @raise [Granite::Action::ValidationError] Action or associated objects are invalid
       # @raise [NotImplementedError] execute_perform! method was not defined yet
       def perform!(context: nil, **options)
-        transactional do
+        transaction do
           validate!(context)
           perform_action!(**options)
         end
@@ -88,7 +88,7 @@ module Granite
       # @raise [NotImplementedError] execute_perform! method was not defined yet
       def try_perform!(context: nil, **options)
         return unless satisfy_preconditions?
-        transactional do
+        transaction do
           validate!(context)
           perform_action!(**options)
         end

--- a/lib/granite/action/transaction.rb
+++ b/lib/granite/action/transaction.rb
@@ -22,10 +22,16 @@ module Granite
         end
       end
 
-      def run_callbacks_with_rescue(event)
-        run_callbacks event
-      rescue *_exception_handlers.keys => e
-        handle_exception(e)
+      def run_callbacks(event)
+        if event.to_s == 'commit'
+          begin
+            super event
+          rescue *_exception_handlers.keys => e
+            handle_exception(e)
+          end
+        else
+          super event
+        end
       end
 
       private

--- a/lib/granite/action/transaction.rb
+++ b/lib/granite/action/transaction.rb
@@ -26,7 +26,7 @@ module Granite
         if event.to_s == 'commit'
           begin
             super event
-          rescue *_exception_handlers.keys => e
+          rescue *handled_exceptions => e
             handle_exception(e)
           end
         else

--- a/lib/granite/action/transaction_manager.rb
+++ b/lib/granite/action/transaction_manager.rb
@@ -67,11 +67,7 @@ module Granite
 
           callback_listeners.reverse.each do |listener|
             begin
-              if listener.respond_to? :run_callbacks_with_rescue
-                listener.run_callbacks_with_rescue :commit
-              else
-                listener.run_callbacks :commit
-              end
+              listener.run_callbacks :commit
             rescue StandardError => e
               collected_errors << e
             end

--- a/lib/granite/action/transaction_manager.rb
+++ b/lib/granite/action/transaction_manager.rb
@@ -1,0 +1,90 @@
+module Granite
+  class Action
+    class Rollback < defined?(ActiveRecord) ? ActiveRecord::Rollback : StandardError
+    end
+
+    module TransactionManager
+      class << self
+        # Runs a block in a transaction
+        # It will open a new transaction or append a block to the current one if it exists
+        #
+        # @param [Object] trigger_callbacks_for - object which will receive `run_callbacks(:commit)` after transaction commited
+        # @return [Object] result of a block
+        def transaction(trigger_callbacks_for: nil, &block)
+          (callback_listeners << trigger_callbacks_for) if trigger_callbacks_for
+
+          if in_a_transaction?
+            yield
+          else
+            wrap_in_transaction_with_callbacks(&block)
+          end
+        end
+
+        private
+
+        IN_A_TRANSACTION_KEY = :granite_transaction_manager_in_a_transaction
+        CALLBACK_LISTENERS_KEY = :granite_transaction_manager_callback_listeners
+
+        def callback_listeners
+          Thread.current[CALLBACK_LISTENERS_KEY] ||= []
+        end
+
+        def in_a_transaction?
+          !!(Thread.current[IN_A_TRANSACTION_KEY])
+        end
+
+        def in_a_transaction=(value)
+          Thread.current[IN_A_TRANSACTION_KEY] = value
+        end
+
+        def wrap_in_transaction_with_callbacks(&block)
+          self.in_a_transaction = true
+
+          result = wrap_in_transaction(&block) || false
+
+          trigger_callbacks if result
+
+          result
+        ensure
+          callback_listeners.clear
+          self.in_a_transaction = nil
+        end
+
+        def wrap_in_transaction(&block)
+          if defined?(ActiveRecord::Base)
+            ActiveRecord::Base.transaction(&block)
+          else
+            begin
+              yield
+            rescue Granite::Action::Rollback
+              false
+            end
+          end
+        end
+
+        def trigger_callbacks
+          collected_errors = []
+
+          callback_listeners.reverse.each do |listener|
+            begin
+              if listener.respond_to? :run_callbacks_with_rescue
+                listener.run_callbacks_with_rescue :commit
+              else
+                listener.run_callbacks :commit
+              end
+            rescue StandardError => e
+              collected_errors << e
+            end
+          end
+
+          if collected_errors.any?
+            collected_errors[1..-1].each do |error|
+              ActiveData.config.logger.error "Unhandled error in callback: #{error.inspect}\n#{error.backtrace.join("\n")}"
+            end
+            fail collected_errors.first
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/granite/action/performing_spec.rb
+++ b/spec/lib/granite/action/performing_spec.rb
@@ -134,47 +134,6 @@ RSpec.describe Granite::Action::Performing do
       specify { expect { Action.new.perform }.to raise_error NotImplementedError }
     end
 
-    context 'when transaction without ActiveRecord' do
-      let(:action) { Action.new(login: 'Login') }
-
-      before do
-        stub_class(:action, Granite::Action) do
-          allow_if { true }
-
-          attribute :login, String
-
-          validates :login, format: /\A\w+\z/
-
-          private
-
-          def execute_perform!(block:)
-            block.call
-          end
-        end
-        hide_const('ActiveRecord::Base')
-        hide_const('ActiveRecord')
-      end
-
-      context 'without exceptions' do
-        specify { expect(action.perform(block: -> { 121 })).to eq(121) }
-      end
-
-      context 'with Granite::Action::Rollback' do
-        let(:klass) do
-          stub_class(:data) do
-            include ActiveData::Model
-            attribute :name, String
-            validates :name, presence: true
-          end
-        end
-        specify { expect(action.perform(block: -> { klass.new.validate! })).to equal(false) }
-      end
-
-      context 'with exception' do
-        specify { expect { action.perform(block: -> { ActiveRecord::Base }) }.to raise_error(NameError, 'uninitialized constant ActiveRecord') }
-      end
-    end
-
     context 'when execute_perform! returns false' do
       before do
         stub_class(:action, Granite::Action) do

--- a/spec/lib/granite/action/transaction_manager_spec.rb
+++ b/spec/lib/granite/action/transaction_manager_spec.rb
@@ -1,0 +1,112 @@
+RSpec.describe Granite::Action::TransactionManager do
+  describe '.transaction' do
+    shared_context 'handles transaction' do
+      subject do
+        described_class.transaction(trigger_callbacks_for: listener) do
+          listener.perform
+          described_class.transaction(trigger_callbacks_for: nested_listener) do
+            nested_listener.perform
+          end
+        end
+      end
+
+      let(:listener) { double }
+      let(:nested_listener) { double }
+
+      it 'returns result of a block and triggers callbacks' do
+        expect(listener).to receive(:perform).ordered
+        expect(nested_listener).to receive(:perform).and_return(121).ordered
+        expect(nested_listener).to receive(:run_callbacks).ordered
+        expect(listener).to receive(:run_callbacks).ordered
+        expect(subject).to eq 121
+      end
+
+      it 'does not trigger callbacks if block returns false' do
+        expect(listener).to receive(:perform).ordered
+        expect(nested_listener).to receive(:perform).and_return(false).ordered
+        expect(subject).to eq false
+      end
+
+      context 'when block fails' do
+        context 'with Granite::Action::Rollback' do
+          context 'for parent' do
+            it 'returns false and does not trigger nested transaction and callbacks' do
+              expect(listener).to receive(:perform) { fail Granite::Action::Rollback }.ordered
+              expect(subject).to eq false
+            end
+          end
+
+          context 'for nested' do
+            it 'returns false and does not trigger callbacks' do
+              expect(listener).to receive(:perform).ordered
+              expect(nested_listener).to receive(:perform) { fail Granite::Action::Rollback }.ordered
+              expect(subject).to eq false
+            end
+          end
+        end
+
+        context 'with exception' do
+          context 'for parent' do
+            it 'raises error and does not trigger nested transacton and callbacks' do
+              expect(listener).to receive(:perform) { fail 'I failed' }.ordered
+              expect { subject }.to raise_error(RuntimeError, 'I failed')
+            end
+          end
+
+          context 'for nested' do
+            it 'raises error and does not trigger callbacks' do
+              expect(listener).to receive(:perform).ordered
+              expect(nested_listener).to receive(:perform) { fail 'I failed' }.ordered
+              expect { subject }.to raise_error(RuntimeError, 'I failed')
+            end
+          end
+        end
+      end
+
+      context 'when callback fails' do
+        before do
+          allow(listener).to receive(:perform)
+          allow(nested_listener).to receive(:perform).and_return(121)
+        end
+
+        context 'for parent' do
+          it 'runs nested callback and fails' do
+            expect(nested_listener).to receive(:run_callbacks).ordered
+            expect(listener).to receive(:run_callbacks) { fail 'I failed' }.ordered
+            expect { subject }.to raise_error(RuntimeError, 'I failed')
+          end
+        end
+
+        context 'for nested' do
+          it 'runs parent callback and fails' do
+            expect(nested_listener).to receive(:run_callbacks) { fail 'I failed' }.ordered
+            expect(listener).to receive(:run_callbacks).ordered
+            expect { subject }.to raise_error(RuntimeError, 'I failed')
+          end
+        end
+
+        context 'for both' do
+          it 'logs second failure and fails with the first' do
+            expect(nested_listener).to receive(:run_callbacks) { fail 'I failed first' }.ordered
+            expect(listener).to receive(:run_callbacks) { fail 'I failed second' }.ordered
+            expect(ActiveData.config.logger).to receive(:error).with(/Unhandled.*RuntimeError.*I failed second.*\n.*transaction_manager_spec.*/)
+            expect { subject }.to raise_error(RuntimeError, 'I failed first')
+          end
+        end
+      end
+    end
+
+    context 'with ActiveRecord' do
+      before do
+        hide_const('ActiveRecord::Base')
+        hide_const('ActiveRecord')
+      end
+
+      include_context 'handles transaction'
+    end
+
+    context 'without ActiveRecord' do
+      include_context 'handles transaction'
+    end
+  end
+end

--- a/spec/lib/granite/action/transaction_spec.rb
+++ b/spec/lib/granite/action/transaction_spec.rb
@@ -1,0 +1,181 @@
+RSpec.describe Granite::Action::Transaction do
+  describe '.handle_exception' do
+    let(:action) { Action.new }
+
+    before do
+      stub_class(:dummy_error, StandardError)
+      stub_class(:action, Granite::Action) do
+        allow_if { true }
+
+        after_commit do
+          fail DummyError, 'Dummy exception'
+        end
+
+        handle_exception(DummyError) do |e|
+          handle_dummy_error(e)
+        end
+      end
+    end
+
+    specify do
+      expect(action).to receive(:execute_perform!)
+      expect(action).to receive(:handle_dummy_error).with(instance_of(DummyError))
+      action.perform!
+    end
+  end
+
+  describe '#transaction' do
+    shared_context 'handles transaction' do
+      subject { action.perform(block: block, nested_action_block: nested_action_block) }
+
+      let(:action) { Action.new }
+      let(:call_chain) { [] }
+      let(:block) { ->{} }
+      let(:nested_action_block) { ->{} }
+
+      before do
+        stub_class(:action, Granite::Action) do
+          allow_if { true }
+
+          after_commit do
+            call_chain << 'action_after_commit'
+          end
+
+          private
+
+          def execute_perform!(block:, nested_action_block:)
+            call_chain << 'action_perform'
+            block.call
+            NestedAction.new.perform!(block: nested_action_block)
+          end
+        end
+
+        stub_class(:nested_action, Granite::Action) do
+          allow_if { true }
+
+          after_commit do
+            call_chain << 'nested_action_after_commit'
+          end
+
+          private
+
+          def execute_perform!(block:)
+            call_chain << 'nested_action_perform'
+            block.call
+          end
+        end
+
+        allow_any_instance_of(Action).to receive(:call_chain).and_return(call_chain)
+        allow_any_instance_of(NestedAction).to receive(:call_chain).and_return(call_chain)
+      end
+
+      context 'and without exceptions' do
+        let(:nested_action_block) { -> { 121 } }
+
+        specify do
+          expect(subject).to eq 121
+          expect(call_chain).to eq %w[action_perform nested_action_perform nested_action_after_commit action_after_commit]
+        end
+      end
+
+      context 'when raises Granite::Action::Rollback' do
+        shared_context 'raises Granite::Action::Rollback' do
+          let(:klass) do
+            stub_class(:data) do
+              include ActiveData::Model
+              attribute :name, String
+              validates :name, presence: true
+            end
+          end
+
+          specify do
+            expect(subject).to eq false
+            expect(call_chain).to eq expected_call_chain
+          end
+        end
+
+        context 'by a parent action' do
+          let(:block) { -> { klass.new.validate! } }
+          let(:expected_call_chain) { %w[action_perform] }
+
+          include_context 'raises Granite::Action::Rollback'
+        end
+
+        context 'by a nested action' do
+          let(:nested_action_block) { -> { klass.new.validate! } }
+          let(:expected_call_chain) {  %w[action_perform nested_action_perform]}
+
+          include_context 'raises Granite::Action::Rollback'
+        end
+      end
+
+      context 'when raises exception' do
+        shared_context 'raises exception' do
+          specify do
+            expect { subject }.to raise_error(RuntimeError, 'I failed')
+            expect(call_chain).to eq expected_call_chain
+          end
+        end
+
+        context 'by a parent action' do
+          let(:block) { -> { fail 'I failed' } }
+          let(:expected_call_chain) { %w[action_perform] }
+
+          include_context 'raises exception'
+        end
+
+        context 'by a nested action' do
+          let(:nested_action_block) { -> { fail 'I failed' } }
+          let(:expected_call_chain) { %w[action_perform nested_action_perform] }
+
+          include_context 'raises exception'
+        end
+      end
+
+      context 'when callback fails' do
+        context 'for parent action' do
+          before do
+            class Action
+              after_commit do
+                fail 'after_commit failed'
+              end
+            end
+          end
+
+          specify do
+            expect { subject }.to raise_error(RuntimeError, 'after_commit failed')
+            expect(call_chain).to eq %w[action_perform nested_action_perform nested_action_after_commit]
+          end
+        end
+
+        context 'for nested action action' do
+          before do
+            class NestedAction
+              after_commit do
+                fail 'after_commit failed'
+              end
+            end
+          end
+
+          specify do
+            expect { subject }.to raise_error(RuntimeError, 'after_commit failed')
+            expect(call_chain).to eq %w[action_perform nested_action_perform action_after_commit]
+          end
+        end
+      end
+    end
+
+    context 'with ActiveRecord' do
+      before do
+        hide_const('ActiveRecord::Base')
+        hide_const('ActiveRecord')
+      end
+
+      include_context 'handles transaction'
+    end
+
+    context 'without ActiveRecord' do
+      include_context 'handles transaction'
+    end
+  end
+end

--- a/spec/lib/granite/action/transaction_spec.rb
+++ b/spec/lib/granite/action/transaction_spec.rb
@@ -1,181 +1,49 @@
 RSpec.describe Granite::Action::Transaction do
-  describe '.handle_exception' do
+  describe 'after_commit' do
+    subject { action.perform! }
+
     let(:action) { Action.new }
 
-    before do
-      stub_class(:dummy_error, StandardError)
-      stub_class(:action, Granite::Action) do
-        allow_if { true }
-
-        after_commit do
-          fail DummyError, 'Dummy exception'
-        end
-
-        handle_exception(DummyError) do |e|
-          handle_dummy_error(e)
-        end
-      end
-    end
-
-    specify do
-      expect(action).to receive(:execute_perform!)
-      expect(action).to receive(:handle_dummy_error).with(instance_of(DummyError))
-      action.perform!
-    end
-  end
-
-  describe '#transaction' do
-    shared_context 'handles transaction' do
-      subject { action.perform(block: block, nested_action_block: nested_action_block) }
-
-      let(:action) { Action.new }
-      let(:call_chain) { [] }
-      let(:block) { ->{} }
-      let(:nested_action_block) { ->{} }
-
+    context 'when raises error' do
       before do
+        stub_class(:dummy_error, StandardError)
+
         stub_class(:action, Granite::Action) do
           allow_if { true }
 
           after_commit do
-            call_chain << 'action_after_commit'
+            fail DummyError, 'Dummy exception'
           end
-
-          private
-
-          def execute_perform!(block:, nested_action_block:)
-            call_chain << 'action_perform'
-            block.call
-            NestedAction.new.perform!(block: nested_action_block)
-          end
-        end
-
-        stub_class(:nested_action, Granite::Action) do
-          allow_if { true }
-
-          after_commit do
-            call_chain << 'nested_action_after_commit'
-          end
-
-          private
-
-          def execute_perform!(block:)
-            call_chain << 'nested_action_perform'
-            block.call
-          end
-        end
-
-        allow_any_instance_of(Action).to receive(:call_chain).and_return(call_chain)
-        allow_any_instance_of(NestedAction).to receive(:call_chain).and_return(call_chain)
-      end
-
-      context 'and without exceptions' do
-        let(:nested_action_block) { -> { 121 } }
-
-        specify do
-          expect(subject).to eq 121
-          expect(call_chain).to eq %w[action_perform nested_action_perform nested_action_after_commit action_after_commit]
         end
       end
 
-      context 'when raises Granite::Action::Rollback' do
-        shared_context 'raises Granite::Action::Rollback' do
-          let(:klass) do
-            stub_class(:data) do
-              include ActiveData::Model
-              attribute :name, String
-              validates :name, presence: true
+      context 'which is unhandled' do
+        before do
+          class Action
+          end
+        end
+
+        it 'fails' do
+          expect(action).to receive(:execute_perform!)
+          expect{subject}.to raise_error(DummyError, 'Dummy exception')
+        end
+      end
+
+      context 'which is handled by `handle_exception`' do
+        before do
+          class Action
+            handle_exception(DummyError) do |e|
+              handle_dummy_error(e)
             end
           end
-
-          specify do
-            expect(subject).to eq false
-            expect(call_chain).to eq expected_call_chain
-          end
         end
 
-        context 'by a parent action' do
-          let(:block) { -> { klass.new.validate! } }
-          let(:expected_call_chain) { %w[action_perform] }
-
-          include_context 'raises Granite::Action::Rollback'
-        end
-
-        context 'by a nested action' do
-          let(:nested_action_block) { -> { klass.new.validate! } }
-          let(:expected_call_chain) {  %w[action_perform nested_action_perform]}
-
-          include_context 'raises Granite::Action::Rollback'
+        it 'does not fail' do
+          expect(action).to receive(:execute_perform!)
+          expect(action).to receive(:handle_dummy_error).with(instance_of(DummyError))
+          subject
         end
       end
-
-      context 'when raises exception' do
-        shared_context 'raises exception' do
-          specify do
-            expect { subject }.to raise_error(RuntimeError, 'I failed')
-            expect(call_chain).to eq expected_call_chain
-          end
-        end
-
-        context 'by a parent action' do
-          let(:block) { -> { fail 'I failed' } }
-          let(:expected_call_chain) { %w[action_perform] }
-
-          include_context 'raises exception'
-        end
-
-        context 'by a nested action' do
-          let(:nested_action_block) { -> { fail 'I failed' } }
-          let(:expected_call_chain) { %w[action_perform nested_action_perform] }
-
-          include_context 'raises exception'
-        end
-      end
-
-      context 'when callback fails' do
-        context 'for parent action' do
-          before do
-            class Action
-              after_commit do
-                fail 'after_commit failed'
-              end
-            end
-          end
-
-          specify do
-            expect { subject }.to raise_error(RuntimeError, 'after_commit failed')
-            expect(call_chain).to eq %w[action_perform nested_action_perform nested_action_after_commit]
-          end
-        end
-
-        context 'for nested action action' do
-          before do
-            class NestedAction
-              after_commit do
-                fail 'after_commit failed'
-              end
-            end
-          end
-
-          specify do
-            expect { subject }.to raise_error(RuntimeError, 'after_commit failed')
-            expect(call_chain).to eq %w[action_perform nested_action_perform action_after_commit]
-          end
-        end
-      end
-    end
-
-    context 'with ActiveRecord' do
-      before do
-        hide_const('ActiveRecord::Base')
-        hide_const('ActiveRecord')
-      end
-
-      include_context 'handles transaction'
-    end
-
-    context 'without ActiveRecord' do
-      include_context 'handles transaction'
     end
   end
 end


### PR DESCRIPTION
Now you can define `after_commit` hook inside your action

```ruby
after_commit do
  "some logic here"
end
```
or
```ruby
after_commit :method_name
```

### Review

- [x] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
