### PR TITLE
Accept blocks as callback listeners in TransactionManager

### DIFF
--- a/lib/granite/action/transaction.rb
+++ b/lib/granite/action/transaction.rb
@@ -36,8 +36,11 @@ module Granite
 
       private
 
-      def transaction(&block)
-        self.class.transaction(trigger_callbacks_for: self, &block)
+      def transaction
+        TransactionManager.transaction do
+          TransactionManager.after_commit(self)
+          yield
+        end
       end
     end
   end

--- a/spec/lib/granite/action/transaction_manager_spec.rb
+++ b/spec/lib/granite/action/transaction_manager_spec.rb
@@ -1,97 +1,110 @@
 RSpec.describe Granite::Action::TransactionManager do
   describe '.transaction' do
-    shared_context 'handles transaction' do
+    shared_examples 'handles transaction' do
       subject do
-        described_class.transaction(trigger_callbacks_for: listener) do
-          listener.perform
-          described_class.transaction(trigger_callbacks_for: nested_listener) do
-            nested_listener.perform
-          end
+        described_class.transaction do
+          123
         end
       end
 
-      let(:listener) { double }
-      let(:nested_listener) { double }
+      let(:block_listener) { double(do_stuff: true) }
+      let(:object_listener) { double(run_callbacks: true) }
 
-      it 'returns result of a block and triggers callbacks' do
-        expect(listener).to receive(:perform).ordered
-        expect(nested_listener).to receive(:perform).and_return(121).ordered
-        expect(nested_listener).to receive(:run_callbacks).ordered
-        expect(listener).to receive(:run_callbacks).ordered
-        expect(subject).to eq 121
+      before do
+        described_class.after_commit { block_listener.do_stuff }
+        described_class.after_commit(object_listener)
       end
 
-      it 'does not trigger callbacks if block returns false' do
-        expect(listener).to receive(:perform).ordered
-        expect(nested_listener).to receive(:perform).and_return(false).ordered
-        expect(subject).to eq false
+
+      it 'returns result of a block and triggers registered callbacks' do
+        expect(object_listener).to receive(:run_callbacks).with(:commit).ordered
+        expect(block_listener).to receive(:do_stuff).ordered
+        expect(subject).to eq 123
       end
 
-      context 'when block fails' do
+      context 'when transaction fails' do
+        subject do
+          described_class.transaction do
+            false
+          end
+        end
+
+        it 'returns result of a block and does not trigger registered callbacks' do
+          expect(object_listener).not_to receive(:run_callbacks)
+          expect(block_listener).not_to receive(:do_stuff)
+          expect(subject).to eq false
+        end
+
+
         context 'with Granite::Action::Rollback' do
-          context 'for parent' do
-            it 'returns false and does not trigger nested transaction and callbacks' do
-              expect(listener).to receive(:perform) { fail Granite::Action::Rollback }.ordered
-              expect(subject).to eq false
+          subject do
+            described_class.transaction do
+              fail Granite::Action::Rollback
             end
           end
 
-          context 'for nested' do
-            it 'returns false and does not trigger callbacks' do
-              expect(listener).to receive(:perform).ordered
-              expect(nested_listener).to receive(:perform) { fail Granite::Action::Rollback }.ordered
-              expect(subject).to eq false
-            end
+          it 'returns false and does not trigger callbacks' do
+            expect(object_listener).not_to receive(:run_callbacks)
+            expect(block_listener).not_to receive(:do_stuff)
+            expect(subject).to eq false
           end
         end
 
-        context 'with exception' do
-          context 'for parent' do
-            it 'raises error and does not trigger nested transacton and callbacks' do
-              expect(listener).to receive(:perform) { fail 'I failed' }.ordered
-              expect { subject }.to raise_error(RuntimeError, 'I failed')
+        context 'with StandardError' do
+          subject do
+            described_class.transaction do
+              fail 'I failed'
             end
           end
 
-          context 'for nested' do
-            it 'raises error and does not trigger callbacks' do
-              expect(listener).to receive(:perform).ordered
-              expect(nested_listener).to receive(:perform) { fail 'I failed' }.ordered
-              expect { subject }.to raise_error(RuntimeError, 'I failed')
-            end
+          it 'fails and doesnt run callbacks' do
+            expect(object_listener).not_to receive(:run_callbacks)
+            expect(block_listener).not_to receive(:do_stuff)
+            expect { subject }.to raise_error(RuntimeError, 'I failed')
           end
+        end
+      end
+
+      context 'with nested transaction' do
+        subject do
+          described_class.transaction do
+            described_class.transaction do
+              fail 'I failed'
+            end
+            456
+          end
+        end
+
+        it 'does not run callbacks if child transaction failed' do
+          expect(object_listener).not_to receive(:run_callbacks)
+          expect(block_listener).not_to receive(:do_stuff)
+          expect { subject }.to raise_error(RuntimeError, 'I failed')
         end
       end
 
       context 'when callback fails' do
         before do
-          allow(listener).to receive(:perform)
-          allow(nested_listener).to receive(:perform).and_return(121)
+          described_class.after_commit { fail 'callback failed' }
         end
 
-        context 'for parent' do
-          it 'runs nested callback and fails' do
-            expect(nested_listener).to receive(:run_callbacks).ordered
-            expect(listener).to receive(:run_callbacks) { fail 'I failed' }.ordered
-            expect { subject }.to raise_error(RuntimeError, 'I failed')
-          end
+        it 'calls for every callback and fails with first callback error' do
+          expect(object_listener).to receive(:run_callbacks).with(:commit).ordered
+          expect(block_listener).to receive(:do_stuff).ordered
+          expect { subject }.to raise_error 'callback failed'
+        end
+      end
+
+      context 'when multiple callbacks fail' do
+        before do
+          described_class.after_commit { fail 'callback failed second' }
+          described_class.after_commit { fail 'callback failed first' }
         end
 
-        context 'for nested' do
-          it 'runs parent callback and fails' do
-            expect(nested_listener).to receive(:run_callbacks) { fail 'I failed' }.ordered
-            expect(listener).to receive(:run_callbacks).ordered
-            expect { subject }.to raise_error(RuntimeError, 'I failed')
-          end
-        end
-
-        context 'for both' do
-          it 'logs second failure and fails with the first' do
-            expect(nested_listener).to receive(:run_callbacks) { fail 'I failed first' }.ordered
-            expect(listener).to receive(:run_callbacks) { fail 'I failed second' }.ordered
-            expect(ActiveData.config.logger).to receive(:error).with(/Unhandled.*RuntimeError.*I failed second.*\n.*transaction_manager_spec.*/)
-            expect { subject }.to raise_error(RuntimeError, 'I failed first')
-          end
+        it 'calls for every callback, fails with first callback error and logs others' do
+          expect(object_listener).to receive(:run_callbacks).with(:commit).ordered
+          expect(block_listener).to receive(:do_stuff).ordered
+          expect(ActiveData.config.logger).to receive(:error).with(/Unhandled.*RuntimeError.*callback failed second.*\n.*transaction_manager_spec.*/)
+          expect { subject }.to raise_error 'callback failed first'
         end
       end
     end
@@ -102,11 +115,11 @@ RSpec.describe Granite::Action::TransactionManager do
         hide_const('ActiveRecord')
       end
 
-      include_context 'handles transaction'
+      include_examples 'handles transaction'
     end
 
     context 'without ActiveRecord' do
-      include_context 'handles transaction'
+      include_examples 'handles transaction'
     end
   end
 end

--- a/spec/lib/granite/action/transaction_spec.rb
+++ b/spec/lib/granite/action/transaction_spec.rb
@@ -46,4 +46,26 @@ RSpec.describe Granite::Action::Transaction do
       end
     end
   end
+
+  describe 'transaction' do
+    subject { action.perform! }
+
+    let(:action) { Action.new }
+
+    before do
+      stub_class(:action, Granite::Action) do
+        allow_if { true }
+
+        def execute_perform!(*)
+          true
+        end
+      end
+    end
+
+    it 'opens a transaction and registers self as a callback' do
+      expect(Granite::Action::TransactionManager).to receive(:transaction).ordered.and_call_original
+      expect(Granite::Action::TransactionManager).to receive(:after_commit).ordered.with(action)
+      subject
+    end
+  end
 end


### PR DESCRIPTION
In order to support better control around transactions, we need to accept blocks as callback listeners.

### Review

- [x] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
