### PR TITLE
Fix issue with represented attributes and default values

### DIFF
--- a/granite.gemspec
+++ b/granite.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.add_runtime_dependency 'actionpack', '~> 5.1'
-  s.add_runtime_dependency 'active_data', '1.1.2'
+  s.add_runtime_dependency 'active_data', '~> 1.1.3'
   s.add_runtime_dependency 'activesupport', '~>5.1'
   s.add_runtime_dependency 'memoist', '~> 0.16'
 

--- a/lib/granite.rb
+++ b/lib/granite.rb
@@ -23,6 +23,7 @@ require 'granite/dispatcher'
 require 'granite/action'
 require 'granite/projector'
 require 'granite/routing'
+require 'granite/typecasters'
 require 'granite/rails' if defined?(::Rails)
 
 ActiveData.base_concern = Granite::Base

--- a/lib/granite/represents/attribute.rb
+++ b/lib/granite/represents/attribute.rb
@@ -43,7 +43,7 @@ module Granite
         return unless reference.respond_to?(reader)
 
         variable_cache(:value) do
-          normalize(enumerize(reference.public_send(reader)))
+          normalize(enumerize(typecast(defaultize(reference.public_send(reader)))))
         end
       end
 
@@ -59,6 +59,8 @@ module Granite
         return nil unless reference.is_a?(ActiveData::Model)
 
         reference_attribute = reference.attribute(name)
+
+        return nil if reference_attribute.nil?
 
         return Granite::Action::Types::Collection.new(reference_attribute.type) if [
           ActiveData::Model::Attributes::ReferenceMany,

--- a/lib/granite/typecasters.rb
+++ b/lib/granite/typecasters.rb
@@ -1,0 +1,10 @@
+require 'active_data'
+
+ActiveData.typecaster('Granite::Action::Types::Collection') do |value, attribute|
+  typecaster = ActiveData.typecaster(attribute.type.subtype)
+  if value.respond_to? :transform_values
+    value.transform_values { |v| typecaster.call(v, attribute) }
+  elsif value.respond_to?(:map)
+    value.map { |v| typecaster.call(v, attribute) }
+  end
+end

--- a/spec/lib/granite/represents/attribute_spec.rb
+++ b/spec/lib/granite/represents/attribute_spec.rb
@@ -9,12 +9,14 @@ RSpec.describe Granite::Represents::Attribute do
       include ActiveData::Model
 
       attribute :sign_in_count, Integer, default: '1'
+      attribute :created_at, Time
     end
 
     stub_class(:action, Granite::Action) do
       allow_if { true }
 
       represents :sign_in_count, of: :user
+      represents :created_at, default: -> { '2000-10-10' }, of: :user
       represents :related_ids, of: :user
 
       def user
@@ -30,6 +32,18 @@ RSpec.describe Granite::Represents::Attribute do
 
     it 'sets default value_before_type_cast' do
       expect(subject.read_before_type_cast).to eq('1')
+    end
+
+    context 'when represented attribute has default value' do
+      subject { action.attribute(:created_at) }
+
+      it 'sets default value' do
+        expect(subject.read).to eq Time.zone.parse('2000-10-10')
+      end
+
+      it 'sets default value_before_type_cast' do
+        expect(subject.read_before_type_cast).to eq('2000-10-10')
+      end
     end
   end
 


### PR DESCRIPTION
When represented attribute had default value defined it may happen
that `read` and `read_before_type_cast` return 2 different values.

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [x] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Squash related commits together.