### PR TITLE
Do not swallow Rollback error without ActiveRecord

### DIFF
--- a/lib/granite/action/transaction_manager.rb
+++ b/lib/granite/action/transaction_manager.rb
@@ -59,11 +59,7 @@ module Granite
           if defined?(ActiveRecord::Base)
             ActiveRecord::Base.transaction(&block)
           else
-            begin
-              yield
-            rescue Granite::Action::Rollback
-              false
-            end
+            yield
           end
         end
 

--- a/spec/lib/granite/action/transaction_manager_spec.rb
+++ b/spec/lib/granite/action/transaction_manager_spec.rb
@@ -36,20 +36,6 @@ RSpec.describe Granite::Action::TransactionManager do
         end
 
 
-        context 'with Granite::Action::Rollback' do
-          subject do
-            described_class.transaction do
-              fail Granite::Action::Rollback
-            end
-          end
-
-          it 'returns false and does not trigger callbacks' do
-            expect(object_listener).not_to receive(:run_callbacks)
-            expect(block_listener).not_to receive(:do_stuff)
-            expect(subject).to eq false
-          end
-        end
-
         context 'with StandardError' do
           subject do
             described_class.transaction do
@@ -110,15 +96,29 @@ RSpec.describe Granite::Action::TransactionManager do
     end
 
     context 'with ActiveRecord' do
+      include_examples 'handles transaction'
+
+      context 'when transaction fails with Granite::Action::Rollback' do
+        subject do
+          described_class.transaction do
+            fail Granite::Action::Rollback
+          end
+        end
+
+        it 'returns false and does not trigger callbacks' do
+          expect(object_listener).not_to receive(:run_callbacks)
+          expect(block_listener).not_to receive(:do_stuff)
+          expect(subject).to eq false
+        end
+      end
+    end
+
+    context 'without ActiveRecord' do
       before do
         hide_const('ActiveRecord::Base')
         hide_const('ActiveRecord')
       end
 
-      include_examples 'handles transaction'
-    end
-
-    context 'without ActiveRecord' do
       include_examples 'handles transaction'
     end
   end


### PR DESCRIPTION
When someone uses Granite without AR - it is better to raise Rollback error when it happens.
So, devs can define a custom error handler for such errors and have better control on it

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
