### PR TITLE
Fix sync error for `represents` with default option

### DIFF
--- a/lib/granite/represents.rb
+++ b/lib/granite/represents.rb
@@ -14,7 +14,7 @@ module Granite
           add_attribute Granite::Represents::Reflection, field, options, &block
 
           before_validation do
-            attribute(field).sync if __send__ "#{field}_changed?"
+            attribute(field).sync if attribute(field).changed?
             true
           end
         end

--- a/lib/granite/represents/attribute.rb
+++ b/lib/granite/represents/attribute.rb
@@ -33,6 +33,14 @@ module Granite
                         end
       end
 
+      def changed?
+        if reflection.options[:default].present?
+          reference.public_send(reader) != read
+        else
+          owner.public_send("#{name}_changed?")
+        end
+      end
+
       private
 
       def reference

--- a/spec/lib/granite/represents_spec.rb
+++ b/spec/lib/granite/represents_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe Granite::Represents do
     end
   end
 
+  shared_examples 'sync attribute value' do
+    it 'syncs before validation if value was changed' do
+      subject
+      expect_any_instance_of(Granite::Represents::Attribute).to receive(:sync)
+      subject.field = new_value
+      subject.valid?
+    end
+  end
+
   it 'contains custom represented attribute' do
     expect(Action.reflect_on_attribute(:field)).to be_a(Granite::Represents::Reflection)
   end
@@ -46,12 +55,40 @@ RSpec.describe Granite::Represents do
 
   context 'when value was changed' do
     let(:attributes) { {field: 2} }
+    let(:new_value) { 3 }
 
-    it 'syncs before validation if value was changed' do
-      subject
-      expect_any_instance_of(Granite::Represents::Attribute).to receive(:sync)
-      subject.field = 3
-      subject.valid?
+    include_examples 'sync attribute value'
+  end
+
+  context 'when attrbute has default value' do
+    before do
+      stub_class(:model) do
+        include ActiveModel::Validations
+
+        attr_accessor :field
+      end
+
+      stub_class(:action, Granite::Action) do
+        allow_if { true }
+
+        represents :field, of: :model, default: 10
+
+        def model
+          @model ||= Model.new
+        end
+      end
+    end
+
+    context 'when new value equal default value' do
+      let(:new_value) { 10 }
+
+      include_examples 'sync attribute value'
+    end
+
+    context 'when new value not equal default value' do
+      let(:new_value) { 5 }
+
+      include_examples 'sync attribute value'
     end
   end
 end


### PR DESCRIPTION
When you try to

```represents :field, of: :model, default: 'default'```

attribute value will not be synched with a reference because attribute
not changed. But it should, because it differs from model value.

### Review

- [x] All tests are passing.
- [x] Test manually.
- [x] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Squash related commits together.
