### PR TITLE
Allow regular expressions to be used in satisfy_preconstions matcher

### DIFF
--- a/spec/lib/granite/rspec/satisfy_preconditions_spec.rb
+++ b/spec/lib/granite/rspec/satisfy_preconditions_spec.rb
@@ -2,9 +2,11 @@ RSpec.describe 'satisfy_preconditions', aggregate_failures: false do
   before do
     stub_class(:action, Granite::Action) do
       attribute :fail_precondition, Boolean
+      attribute :second_fail_precondition, Boolean
 
       precondition do
         decline_with 'Precondition failed' if fail_precondition
+        decline_with 'Multiple failures' if second_fail_precondition
       end
     end
   end
@@ -25,6 +27,10 @@ RSpec.describe 'satisfy_preconditions', aggregate_failures: false do
     let(:action) { Action.new(fail_precondition: true) }
 
     specify { expect(action).not_to satisfy_preconditions.with_message('Precondition failed') }
+
+    specify { expect(action).not_to satisfy_preconditions.with_message(/failed$/) }
+
+    specify { expect(action).not_to satisfy_preconditions.with_messages('Precondition failed', /failed$/, /^Precondition/) }
 
     specify do
       expect do
@@ -54,6 +60,24 @@ RSpec.describe 'satisfy_preconditions', aggregate_failures: false do
       expect do
         expect(action).not_to satisfy_preconditions.with_message_of_kind(:custom_message).exactly
       end.to fail_with(%(expected #{action} not to satisfy preconditions with error messages of kind [:custom_message] but got following kind of error messages:\n    [:error]))
+    end
+  end
+
+  context 'with multiple failing preconditions' do
+    let(:action) { Action.new(fail_precondition: true, second_fail_precondition: true) }
+
+    specify { expect(action).not_to satisfy_preconditions.with_message('Precondition failed') }
+
+    specify { expect(action).not_to satisfy_preconditions.with_message('Multiple failures') }
+
+    context 'with `exactly`' do
+      specify do
+        expect do
+          expect(action).not_to satisfy_preconditions.with_message('Precondition failed').exactly
+        end.to fail_with(%(expected #{action} not to satisfy preconditions exactly with error messages ["Precondition failed"] but got following error messages:\n    ["Precondition failed", "Multiple failures"]))
+      end
+
+      specify { expect(action).not_to satisfy_preconditions.with_message(/failed|failures/).exactly }
     end
   end
 end


### PR DESCRIPTION
This allows matching on a message using a regular expression.

On a side note, I don't see what's the difference whether you use `.exactly` or not - the check is implemented differently, but test the same.

In my opinion, a better API would be if `with_message` and `with_messages` allow testing for a subset of the generated error messages, while `exactly` requires that all the messages are matched. This means moving the `all_messages_match && all_errors_expected` to the `@exactly` branch and leaving in the `else`  only the first check. 

I would be happy to update this/add a follow-up PR if you agree on this subject.

### Review

- [x] ~Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).~
- [x] All tests are passing.
- [x] Test manually.
- [x] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Squash related commits together.
