### PR TITLE
Fix satisfy_preconditions matcher to work with String type messages

### DIFF
--- a/app/controllers/granite/controller.rb
+++ b/app/controllers/granite/controller.rb
@@ -16,9 +16,7 @@ module Granite
     def projector
       @projector ||= begin
         action_projector_class = action_class.public_send(projector_name)
-        if respond_to?(:projector_performer, true)
-          action_projector_class = action_projector_class.as(projector_performer)
-        end
+        action_projector_class = action_projector_class.as(projector_performer) if respond_to?(:projector_performer, true)
         action_projector_class.new(projector_params)
       end
     end

--- a/lib/granite/action.rb
+++ b/lib/granite/action.rb
@@ -32,9 +32,7 @@ module Granite
       def assign_attributes(attributes)
         attributes = attributes.to_unsafe_hash if attributes.respond_to?(:to_unsafe_hash)
         attributes = attributes.stringify_keys
-        if attributes.key?(model_name.param_key)
-          attributes = attributes.merge(attributes.delete(model_name.param_key))
-        end
+        attributes = attributes.merge(attributes.delete(model_name.param_key)) if attributes.key?(model_name.param_key)
         super(attributes)
       end
     end
@@ -82,9 +80,7 @@ module Granite
     #
     # @return [Boolean] whether action is performable
     def performable?
-      unless instance_variable_defined?(:@performable)
-        @performable = allowed? && satisfy_preconditions?
-      end
+      @performable = allowed? && satisfy_preconditions? unless instance_variable_defined?(:@performable)
       @performable
     end
 

--- a/lib/granite/action/policies.rb
+++ b/lib/granite/action/policies.rb
@@ -7,9 +7,7 @@ module Granite
   class Action
     class NotAllowedError < Error
       def initialize(action)
-        if action.performer.respond_to?(:id) && action.performer.id.present?
-          performer_id = "##{action.performer.id}"
-        end
+        performer_id = "##{action.performer.id}" if action.performer.respond_to?(:id) && action.performer.id.present?
 
         super("#{action.class} action is not allowed " \
               "for #{action.performer.class}#{performer_id}", action)
@@ -75,9 +73,7 @@ module Granite
       # Returns true if any of defined policies returns true
       #
       def allowed?
-        unless instance_variable_defined?(:@allowed)
-          @allowed = _policies_strategy.allowed?(self)
-        end
+        @allowed = _policies_strategy.allowed?(self) unless instance_variable_defined?(:@allowed)
         @allowed
       end
 

--- a/lib/granite/rspec/satisfy_preconditions.rb
+++ b/lib/granite/rspec/satisfy_preconditions.rb
@@ -54,11 +54,9 @@ RSpec::Matchers.define :satisfy_preconditions do
     if @expected_messages
       errors = object.errors[:base]
 
-      result &&= @expected_messages.all? { |expected| errors.any? { |error| error.match? expected } }
+      result &&= @expected_messages.all? { |expected| errors.any? { |error| compare(error, expected) } }
 
-      if @exactly
-        result &&= errors.none? { |error| @expected_messages.none? { |expected| error.match? expected } }
-      end
+      result &&= errors.none? { |error| @expected_messages.none? { |expected| compare(error, expected) } } if @exactly
     elsif @expected_kind_of_messages
       error_kinds = object.errors.details[:base].map(&:values).flatten
       result &&= (@expected_kind_of_messages - error_kinds).empty?
@@ -93,6 +91,14 @@ RSpec::Matchers.define :satisfy_preconditions do
     actual_kind_of_errors = object.errors.details[:base].map(&:keys).flatten
     message += " with error messages of kind #{expected_kind_of_messages}"
     message + " but got following kind of error messages:\n    #{actual_kind_of_errors.inspect}"
+  end
+
+  def compare(error, expected)
+    if expected.is_a? String
+      error == expected
+    else
+      error.match? expected
+    end
   end
 end
 

--- a/spec/lib/granite/rspec/satisfy_preconditions_spec.rb
+++ b/spec/lib/granite/rspec/satisfy_preconditions_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe 'satisfy_preconditions', aggregate_failures: false do
 
     specify do
       expect do
+        expect(action).not_to satisfy_preconditions.with_message('failed')
+      end.to fail_with(%(expected #{action} not to satisfy preconditions with error messages ["failed"] but got following error messages:\n    ["Precondition failed"]))
+    end
+
+    specify do
+      expect do
         expect(action).not_to satisfy_preconditions.with_messages(['WRONG TEXT'])
       end.to fail_with(%(expected #{action} not to satisfy preconditions with error messages ["WRONG TEXT"] but got following error messages:\n    ["Precondition failed"]))
     end


### PR DESCRIPTION
In satisfy_preconditions matcher, all messages were treated as regexp, even if they were actually Strings. This could cause false positives or errors for strings that included regexp special characters.

### Review

- [x] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [x] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Squash related commits together.
