### PR TITLE
Apply association changes in perform block

### DIFF
--- a/lib/granite/action/performing.rb
+++ b/lib/granite/action/performing.rb
@@ -92,8 +92,10 @@ module Granite
       private
 
       def perform_action(raise_errors: false, **options)
-        apply_association_changes!
-        result = run_callbacks(:execute_perform) { execute_perform!(options) }
+        result = run_callbacks(:execute_perform) do
+          apply_association_changes!
+          execute_perform!(options)
+        end
         @_action_performed = true
         result || true
       rescue *handled_exceptions => e


### PR DESCRIPTION
We have changed integration of our app with Granite so that it uses callbacks around `execute_perform` instead of custom transaction block. This let us fix some major issue with validations and improve architecture.

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
