### PR TITLE
Use template1 as database to setup for development

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,4 +3,4 @@
 # A setup script for development environment of Granite
 
 cp spec/support/database.yml.example spec/support/database.yml
-psql template1 -c 'create database granite;' -U granite
+createdb granite

--- a/bin/setup
+++ b/bin/setup
@@ -3,4 +3,4 @@
 # A setup script for development environment of Granite
 
 cp spec/support/database.yml.example spec/support/database.yml
-psql -c 'create database granite;' -U granite
+psql template1 -c 'create database granite;' -U granite


### PR DESCRIPTION
I just tried to reload and update my local env for development and `bin/setup`
failed.

```
⋊> ~/c/t/granite on master ⨯ psql -c 'create database granite;' -U granite                                              17:03:35
psql: FATAL:  database "granite" does not exist
```
And looks like I need to pass the database default to create another database or
use createdb.


- [x] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [ ] Get approval.


- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.