### PR TITLE
Add rails-6 support

### DIFF
--- a/granite.gemspec
+++ b/granite.gemspec
@@ -13,12 +13,12 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n").grep(/\A(app|lib|LICENSE)/)
   s.license     = 'MIT'
 
-  s.add_runtime_dependency 'actionpack', '~> 5.1'
-  s.add_runtime_dependency 'active_data', '~> 1.1.3'
-  s.add_runtime_dependency 'activesupport', '~>5.1'
+  s.add_runtime_dependency 'actionpack', '>= 5.1', '< 6.1'
+  s.add_runtime_dependency 'active_data', '~> 1.1.5'
+  s.add_runtime_dependency 'activesupport', '>= 5.1', '< 6.1'
   s.add_runtime_dependency 'memoist', '~> 0.16'
 
-  s.add_development_dependency 'activerecord', '~> 5.0'
+  s.add_development_dependency 'activerecord', '>= 5.0', '< 6.1'
   s.add_development_dependency 'capybara', '~> 2.18'
   s.add_development_dependency 'fuubar', '~> 2.0'
   s.add_development_dependency 'pg', '< 2'

--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -12,6 +12,7 @@ end
 Rails.application = GraniteApplication.new
 Rails.application.paths['config/database'] << File.expand_path('database.yml', __dir__)
 Rails.application.secrets.secret_key_base = '1234567890'
+Rails.application.config.hosts = 'www.example.com'
 Rails.application.routes_reloader.route_sets << Rails.application.routes
 Rails.configuration.eager_load = false
 Rails.application.initialize!


### PR DESCRIPTION
active_data >= 1.1.5 supports rails-6 & granite works fine with it

### Review

- n/a Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [x] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Squash related commits together.
