### PR TITLE
Add PerformerInInitializer Cop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'rubocop', require: false
+
 gemspec

--- a/docs/index.md
+++ b/docs/index.md
@@ -357,3 +357,12 @@ You can pass a second argument to generator to specify projector name.
       create  apq/actions/ba/user/create.rb
       create  apq/actions/ba/user/business_action.rb
       create  spec/apq/actions/ba/user/create_spec.rb
+
+### RuboCop
+
+You can use Granite specific cops by requiring it in your `.rubocop.yml`
+
+      require:
+        - granite/rubocop
+
+Check out [/lib/granite/rubocop/cop](lib/granite/rubocop/cop) to see what are the options.

--- a/granite.gemspec
+++ b/granite.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'activerecord', '~> 5.0'
   s.add_development_dependency 'capybara', '~> 2.18'
   s.add_development_dependency 'fuubar', '~> 2.0'
-  s.add_development_dependency 'pg', '< 1'
+  s.add_development_dependency 'pg', '< 2'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rspec', '~> 3.6'
   s.add_development_dependency 'rspec-activemodel-mocks', '~> 1.0'

--- a/granite.gemspec
+++ b/granite.gemspec
@@ -13,12 +13,12 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n").grep(/\A(app|lib|LICENSE)/)
   s.license     = 'MIT'
 
-  s.add_runtime_dependency 'actionpack', '~> 5.1'
-  s.add_runtime_dependency 'active_data', '~> 1.1.3'
-  s.add_runtime_dependency 'activesupport', '~>5.1'
+  s.add_runtime_dependency 'actionpack', '>= 5.1', '< 6.1'
+  s.add_runtime_dependency 'active_data', '~> 1.1.5'
+  s.add_runtime_dependency 'activesupport', '>= 5.1', '< 6.1'
   s.add_runtime_dependency 'memoist', '~> 0.16'
 
-  s.add_development_dependency 'activerecord', '~> 5.0'
+  s.add_development_dependency 'activerecord', '>= 5.0', '< 6.1'
   s.add_development_dependency 'capybara', '~> 2.18'
   s.add_development_dependency 'fuubar', '~> 2.0'
   s.add_development_dependency 'pg', '< 2'

--- a/lib/granite/rubocop.rb
+++ b/lib/granite/rubocop.rb
@@ -1,0 +1,2 @@
+require 'rubocop'
+require_relative 'rubocop/cop/performer_in_initializer'

--- a/lib/granite/rubocop/cop/performer_in_initializer.rb
+++ b/lib/granite/rubocop/cop/performer_in_initializer.rb
@@ -1,0 +1,198 @@
+require 'rubocop'
+
+module RuboCop
+  module Cop
+    module Granite
+
+      # Checks if performer is being passed to the BA initializer.
+      #
+      # Instead of initializing, use `.as(performer)` or `.as_system`
+      #
+      # @example
+      #   # bad
+      #   BA::Subject::Action.new(performer: Role.system, other: 'arg')
+      #
+      #   # good
+      #   BA::Subject::Action.as_system.new(other: 'arg')
+      #
+      #   # bad
+      #   BA::Subject::Action.new(subject, performer: subject.author, other: 'arg')
+      #
+      #   # good
+      #   BA::Subject::Action.as(subject.author).new(subject, other: 'arg')
+      class PerformerInInitializer < ::RuboCop::Cop::Cop
+        MSG = 'Use `.as(performer)` or `.as_system` instead of passing performer to the initializer'.freeze
+
+        def on_send(node)
+          return unless business_action?(node) || testing_ba?(node)
+
+          add_offense(node, location: :expression, message: MSG)
+        end
+
+        def autocorrect(node)
+          return if has_method_calls_before_new?(node)
+
+          node = described_class_initialized?(node).parent if testing_ba?(node)
+          if has_performer_as_role?(node)
+            autocorrect_performer_as_role_system(node)
+          else
+            autocorrect_performer_as_expression(node)
+          end
+        end
+
+        private
+
+        def_node_search :under_ba_namespace?, '(:const nil? :BA)'
+        def_node_matcher :described_class_initialized?, '^(send (send _ :described_class) :new $_)'
+        def_node_matcher :describe_block?, '(block (send _ :describe $...) ...)'
+        def_node_search :has_performer_key_in_params?, '(sym :performer)'
+        def_node_search :has_as_expression?, ' (send  _  :as _) '
+        def_node_search :has_performer_as_role?, '(pair #has_performer_key_in_params? (send _ :system))'
+        def_node_search :has_performer_as_role, '(pair #has_performer_key_in_params? (send _ :system))'
+        def_node_search :has_performer_as_expression, '(pair #has_performer_key_in_params? $_)'
+        def_node_matcher :has_method_calls_before_new?, '(send (send ...) :new ...)'
+
+        def business_action?(node)
+          return unless initializer?(node)
+          return unless has_performer_key_in_params?(node)
+
+          under_ba_namespace?(node) && !already_fixed?(node)
+        end
+
+        def already_fixed?(node)
+          has_as_expression?(node)
+        end
+
+        def testing_ba?(node)
+          return false unless described_class_is_ba?(node)
+
+          params = described_class_initialized?(node)
+          params && has_performer_key_in_params?(params)
+        end
+
+        def described_class_is_ba?(node)
+          parent = node.parent
+          while parent
+            describing_class = describe_block?(parent)
+            if describing_class
+              return false if describing_class.empty?
+
+              return under_ba_namespace?(describing_class.first)
+            end
+            parent = parent.parent
+          end
+          false
+        end
+
+        def initializer?(node)
+          node.type == :send && node.method_name == :new
+        end
+
+        def autocorrect_performer_as_role_system(node)
+          params, performer_param_pair = params_and_performer_pair_role(node)
+          performer_injection = 'as_system.'
+          autocorrect_performer(node, performer_injection, params, performer_param_pair)
+        end
+
+        def autocorrect_performer_as_expression(node)
+          params, performer_param_pair = params_and_performer_pair_expression(node)
+          performer_injection = "as(#{performer_param_pair.source})."
+          autocorrect_performer(node, performer_injection, params, performer_param_pair)
+        end
+
+        def autocorrect_performer(node, performer_injection, params, performer_param_pair)
+          lambda do |corrector|
+            position = node.loc
+            corrector.insert_before(position.selector, performer_injection)
+            reject_performer_pair(corrector, params, performer_param_pair)
+          end
+        end
+
+        def reject_performer_pair(corrector, params, performer_param_pair)
+          performer_param_i = performer_param_index(params)
+          return unless performer_param_i
+
+          if params.children.size == 1
+            remove_full_parameters(corrector, params, performer_param_pair) && return
+          end
+
+          if performer_param_i < params.children.size - 1
+            remove_all_from_performer_param_until_next_param(performer_param_i, params, corrector)
+          else
+            remove_performer_param_only(performer_param_i, params, corrector)
+          end
+        end
+
+        def performer_param_index(params)
+          params.children.find_index { |pair| pair.children.first.children.first == :performer }
+        end
+
+        def remove_all_from_performer_param_until_next_param(performer_param_i, params, corrector)
+          performer_param = params.children[performer_param_i]
+          next_param = params.children[performer_param_i + 1]
+
+          begin_pos = performer_param.loc.expression.begin_pos
+          end_pos = next_param.loc.expression.begin_pos
+
+          remove_in_range(corrector, begin_pos, end_pos)
+        end
+
+        def remove_performer_param_only(performer_param_i, params, corrector)
+          performer_param = params.children[performer_param_i]
+          prev_param = params.children[performer_param_i - 1]
+
+          begin_pos = prev_param.loc.expression.end_pos
+          end_pos = performer_param.loc.expression.end_pos
+
+          remove_in_range(corrector, begin_pos, end_pos)
+        end
+
+        def remove_in_range(corrector, begin_pos, end_pos)
+          buffer = processed_source.buffer
+          range = Parser::Source::Range.new(buffer, begin_pos, end_pos)
+          corrector.remove(range)
+        end
+
+        def params_and_performer_pair_expression(node)
+          has_performer_as_expression(node) do |performer_param_pair|
+            params = performer_param_pair.parent.parent
+            return params, performer_param_pair
+          end
+        end
+
+        def params_and_performer_pair_role(node)
+          has_performer_as_role(node) do |performer_param_pair|
+            params = performer_param_pair.parent
+            return params, performer_param_pair
+          end
+        end
+
+        def remove_full_parameters(corrector, params, performer_param_pair)
+          if perform_merge_on_param_hash?(params)
+            corrector.replace params.loc.expression, '{}'
+          else
+            corrector.remove params.loc.expression
+            prev_sibling = previous_sibling(params)
+            corrector.remove range_between(prev_sibling, performer_param_pair) if prev_sibling.respond_to? :loc
+          end
+        end
+
+        def perform_merge_on_param_hash?(params)
+          params.parent.type == :send && params.parent.children.include?(:merge)
+        end
+
+        def range_between(previous, node)
+          buffer = processed_source.buffer
+          begin_pos = previous.loc.expression.end_pos
+          end_pos = node.loc.expression.begin_pos
+          Parser::Source::Range.new(buffer, begin_pos, end_pos)
+        end
+
+        def previous_sibling(node)
+          node_index = node.parent.children.index(node)
+          node.parent.children[node_index - 1]
+        end
+      end
+    end
+  end
+end

--- a/lib/granite/rubocop/cop/performer_in_initializer.rb
+++ b/lib/granite/rubocop/cop/performer_in_initializer.rb
@@ -66,15 +66,13 @@ module RuboCop
         end
 
         def described_class_is_ba?(node)
-          parent = node.parent
-          while parent
-            describing_class = describe_block?(parent)
+          node.each_ancestor do |ancestor|
+            describing_class = describe_block?(ancestor)
             if describing_class
               return false if describing_class.empty?
 
               return under_ba_namespace?(describing_class.first)
             end
-            parent = parent.parent
           end
           false
         end

--- a/spec/lib/granite/rubocop/cop/performer_in_initializer_spec.rb
+++ b/spec/lib/granite/rubocop/cop/performer_in_initializer_spec.rb
@@ -1,0 +1,250 @@
+require 'rubocop/rspec/support'
+require 'granite/rubocop/cop/performer_in_initializer'
+
+RSpec.describe RuboCop::Cop::Granite::PerformerInInitializer do
+  subject(:cop) { described_class.new }
+
+  let(:message) { described_class::MSG }
+
+  before do
+    inspect_source(source)
+  end
+
+  shared_examples 'code without offense' do |code|
+    let(:source) { code }
+
+    it 'does not register an offense' do
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  shared_examples 'code with offense' do |code, corrected = nil|
+    let(:source) { code }
+
+    it 'registers an offense' do
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages).to eq([message])
+    end
+
+    if corrected
+      it 'auto-corrects' do
+        expect(autocorrect_source(code)).to eq(corrected)
+      end
+    else
+      it 'does not auto-correct' do
+        expect(autocorrect_source(code)).to eq(code)
+      end
+    end
+  end
+
+  context 'when is not a real Business Action' do
+    it_behaves_like 'code without offense',
+                    'NotBusinessAction.new(performer: Role.system)'
+
+    it_behaves_like 'code without offense',
+                    'NotBA::Subject::Action.new(performer: Role.system)'
+
+    it_behaves_like 'code without offense',
+                    '5.inspect'
+  end
+
+  context 'when already using the new syntax' do
+    code = 'BA::TshirtOrder::Create.as(attributes.delete(:performer)).new(attributes)'
+    it_behaves_like 'code without offense', code
+  end
+
+  context 'when checking specs using `described_class`' do
+    context 'with role system' do
+      code = <<-CODE
+      describe BA::Subject::Action do
+        subject { described_class.new(performer: Role.system) }
+      end
+      CODE
+      corrected = <<-CORRECTED
+      describe BA::Subject::Action do
+        subject { described_class.as_system.new() }
+      end
+      CORRECTED
+      it_behaves_like 'code with offense', code, corrected
+    end
+
+    context 'with subject and performer' do
+      code = <<-CODE
+      describe BA::Subject::Action do
+        let(:user)   { create(:user) }
+        let(:action) { described_class.new(performer: user, other: 'param') }
+      end
+      CODE
+      corrected = <<-CORRECTED
+      describe BA::Subject::Action do
+        let(:user)   { create(:user) }
+        let(:action) { described_class.as(user).new(other: 'param') }
+      end
+      CORRECTED
+      it_behaves_like 'code with offense', code, corrected
+    end
+
+    context 'when describe block exists' do
+      code = <<-CODE
+        RSpec.describe BA::Talent::Walkthrough::Step do
+          describe do
+          end
+        end
+      CODE
+
+      it_behaves_like 'code without offense', code
+    end
+
+    context 'when params merged with another hash' do
+      context 'when performer is on the left side of the merge' do
+        code = 'BA::Talent::SaveApplication.new(talent, {performer: Role.system}.merge(prohibited_location_attributes)).perform!'
+        corrected = 'BA::Talent::SaveApplication.as_system.new(talent, {}.merge(prohibited_location_attributes)).perform!'
+
+        it_behaves_like 'code with offense', code, corrected
+      end
+
+      context 'when performer is on the right side of the merge' do
+        code = 'let!(:job) { BA::Job::CreateClaimable.new(job_attribute.merge(performer: company)).perform! }'
+        corrected = 'let!(:job) { BA::Job::CreateClaimable.as(company).new(job_attribute.merge({})).perform! }'
+
+        it_behaves_like 'code with offense', code, corrected
+      end
+    end
+
+    context 'when using `Rspec.describe` notation' do
+      code = <<-CODE
+        RSpec.describe BA::Talent::Reactivate do
+          subject(:action) { described_class.new(performer: Role.system) }
+        end
+      CODE
+
+      corrected = <<-CODE
+        RSpec.describe BA::Talent::Reactivate do
+          subject(:action) { described_class.as_system.new() }
+        end
+      CODE
+
+      it_behaves_like 'code with offense', code, corrected
+    end
+  end
+
+  context 'when performer is not passed to the initializer' do
+    it_behaves_like 'code without offense',
+                    'BA::Subject::Action.as_system.new(other: parameter)'
+  end
+
+  context 'when performer is passed to the initializer' do
+    context 'when performer is given as Role.system' do
+      it_behaves_like 'code with offense',
+                      'BA::Subject::Action.new(performer: Role.system)',
+                      'BA::Subject::Action.as_system.new()'
+
+      it_behaves_like 'code with offense',
+                      'BA::Subject::Action.new(performer: Role.system, other_param: param)',
+                      'BA::Subject::Action.as_system.new(other_param: param)'
+    end
+
+    context 'when performer is given as ::Role.system' do
+      it_behaves_like 'code with offense',
+                      'BA::Subject::Action.new(performer: ::Role.system, other_param: param)',
+                      'BA::Subject::Action.as_system.new(other_param: param)'
+    end
+
+    context 'when performer is given as {expression}' do
+      context 'when performer is a method chain' do
+        it_behaves_like 'code with offense',
+                        'BA::Subject::Action.new(other: parameter, performer: subject.author)',
+                        'BA::Subject::Action.as(subject.author).new(other: parameter)'
+      end
+
+      context 'when performer is a single method call or a variable' do
+        it_behaves_like 'code with offense',
+                        'BA::Invoice::AllocateMemorandums.new(document, performer: performer).perform!',
+                        'BA::Invoice::AllocateMemorandums.as(performer).new(document).perform!'
+      end
+    end
+
+    context 'when subject is the first parameter and performer is the second parameter' do
+      it_behaves_like 'code with offense',
+                      'BA::Subject::Action.new(subject, performer: object.message)',
+                      'BA::Subject::Action.as(object.message).new(subject)'
+
+      it_behaves_like 'code with offense',
+                      'BA::Subject::Action.new(subject, performer: ::Role.system).perform!',
+                      'BA::Subject::Action.as_system.new(subject).perform!'
+    end
+
+    context 'when there are other method calls before new' do
+      it_behaves_like 'code with offense',
+                      'BA::Email::SendToRole.modal.new(performer: performer)'
+
+      it_behaves_like 'code with offense',
+                      'BA::Email::SendToRole.for(step_type).new(performer: performer)'
+
+      it_behaves_like 'code with offense',
+                      'BA::Email::SendToRole.modal.new(subject.company, performer: action.performer)'
+    end
+
+    context 'when multi-line initializer' do
+      context 'with system performer' do
+        code = <<-CODE
+          BA::Subject::Action.new(subject,
+              performer: Role.system,
+              other_param: param)
+        CODE
+        corrected = <<-CORRECTED
+          BA::Subject::Action.as_system.new(subject,
+              other_param: param)
+        CORRECTED
+
+        it_behaves_like 'code with offense', code, corrected
+      end
+
+      context 'with other performer' do
+        code = <<-CODE
+          BA::Subject::Action.new(subject,
+              performer: performer,
+              other_param: param)
+        CODE
+        corrected = <<-CORRECTED
+          BA::Subject::Action.as(performer).new(subject,
+              other_param: param)
+        CORRECTED
+
+        it_behaves_like 'code with offense', code, corrected
+      end
+
+      context 'with other performer' do
+        code = <<-CODE
+          BA::Subject::Action.new(subject,
+              performer: performer,
+              other_param: param)
+        CODE
+        corrected = <<-CORRECTED
+          BA::Subject::Action.as(performer).new(subject,
+              other_param: param)
+        CORRECTED
+
+        it_behaves_like 'code with offense', code, corrected
+      end
+
+      context 'with multiple params' do
+        code = <<-CODE
+          BA::Subject::Action.new(subject,
+              performer: performer,
+              first: param,
+              second: param
+          )
+        CODE
+        corrected = <<-CORRECTED
+          BA::Subject::Action.as(performer).new(subject,
+              first: param,
+              second: param
+          )
+        CORRECTED
+
+        it_behaves_like 'code with offense', code, corrected
+      end
+    end
+  end
+end

--- a/spec/lib/granite/rubocop/cop/performer_in_initializer_spec.rb
+++ b/spec/lib/granite/rubocop/cop/performer_in_initializer_spec.rb
@@ -56,16 +56,16 @@ RSpec.describe RuboCop::Cop::Granite::PerformerInInitializer do
   context 'when checking specs using `described_class`' do
     context 'with subject and performer' do
       code = <<-CODE
-      describe BA::Subject::Action do
-        let(:user)   { create(:user) }
-        let(:action) { described_class.new(performer: user, other: 'param') }
-      end
+        describe BA::Subject::Action do
+          let(:user)   { create(:user) }
+          let(:action) { described_class.new(performer: user, other: 'param') }
+        end
       CODE
       corrected = <<-CORRECTED
-      describe BA::Subject::Action do
-        let(:user)   { create(:user) }
-        let(:action) { described_class.as(user).new(other: 'param') }
-      end
+        describe BA::Subject::Action do
+          let(:user)   { create(:user) }
+          let(:action) { described_class.as(user).new(other: 'param') }
+        end
       CORRECTED
       it_behaves_like 'code with offense', code, corrected
     end

--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -12,6 +12,7 @@ end
 Rails.application = GraniteApplication.new
 Rails.application.paths['config/database'] << File.expand_path('database.yml', __dir__)
 Rails.application.secrets.secret_key_base = '1234567890'
+Rails.application.config.hosts = 'www.example.com'
 Rails.application.routes_reloader.route_sets << Rails.application.routes
 Rails.configuration.eager_load = false
 Rails.application.initialize!


### PR DESCRIPTION
We're moving Granite specific Cop away form our internal projects. This is the first one. 

It is checking if the performer is not passed in the initializer like an ordinary attribute:

```ruby
  BA::MyAction.new(subject, performer: me)
```

But requires a canonical

```ruby
  BA::MyAction.as(me).new(subject)
```

Original contributors were:
@jonatas @phss @liptonshmidt

Please note: I'm not sure Granite is the best place for it (requiring Granite will pull in RuboCop, even though some people might want to use `Granite` without extra dependencies).  

## Todo
- [ ] extract `.as_system` cop or drop it completely?

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
