### PR TITLE
Symbolize path helper options

### DIFF
--- a/lib/granite/projector/controller_actions.rb
+++ b/lib/granite/projector/controller_actions.rb
@@ -23,11 +23,11 @@ module Granite
             controller_class.__send__(:define_method, name, &block)
             class_eval <<-METHOD, __FILE__, __LINE__ + 1
               def #{name}_url(options = {})
-                action_url(:#{name}, options)
+                action_url(:#{name}, options.symbolize_keys)
               end
 
               def #{name}_path(options = {})
-                action_path(:#{name}, options)
+                action_path(:#{name}, options.symbolize_keys)
               end
             METHOD
           else

--- a/spec/lib/granite/projector/controller_actions_spec.rb
+++ b/spec/lib/granite/projector/controller_actions_spec.rb
@@ -78,11 +78,19 @@ RSpec.describe Granite::Projector::ControllerActions, type: :granite_projector d
       describe '##{action}_url' do
         specify { expect(projector.confirm_url(foo: 'string')).to eq('http://test.host/students/action/confirm?foo=string') }
         specify { expect(projector.perform_url(anchor: 'ok')).to eq('http://test.host/students/action/perform#ok') }
+
+        context 'with option keys provides as strings' do
+          specify { expect(projector.perform_url('anchor' => 'ok')).to eq('http://test.host/students/action/perform#ok') }
+        end
       end
 
       describe '##{action}_path' do
         specify { expect(projector.confirm_path).to eq('/students/action/confirm') }
         specify { expect(projector.perform_path(bar: 'string')).to eq('/students/action/perform?bar=string') }
+
+        context 'with option keys provides as strings' do
+          specify { expect(projector.perform_path('bar' => 'string')).to eq('/students/action/perform?bar=string') }
+        end
       end
     end
 
@@ -101,11 +109,19 @@ RSpec.describe Granite::Projector::ControllerActions, type: :granite_projector d
       describe '##{action}_url' do
         specify { expect(projector.confirm_url(foo: 'string')).to eq('http://test.host/students/42/action/confirm?foo=string') }
         specify { expect(projector.perform_url(anchor: 'ok')).to eq('http://test.host/students/42/action/perform#ok') }
+
+        context 'with option keys provides as strings' do
+          specify { expect(projector.perform_url('anchor' => 'ok')).to eq('http://test.host/students/42/action/perform#ok') }
+        end
       end
 
       describe '##{action}_path' do
         specify { expect(projector.confirm_path).to eq('/students/42/action/confirm') }
         specify { expect(projector.perform_path(bar: 'string')).to eq('/students/42/action/perform?bar=string') }
+
+        context 'with option keys provides as strings' do
+          specify { expect(projector.perform_path('bar' => 'string')).to eq('/students/42/action/perform?bar=string') }
+        end
       end
     end
   end


### PR DESCRIPTION
The `_path` helper method is currently failing when the options are provides with string keys (e.g. `projector.perform_path('bar' => 'string')` instead of `projector.perform_path(bar: 'string')`).

It may be errorprone sometimes, cause `ActiveData` holds it's attribute names as strings. So the construction like `perform_path(action.attributes)` for example will fail.