### PR TITLE
Add rubocop config that can be required project using granite

### DIFF
--- a/config/rubocop-default.yml
+++ b/config/rubocop-default.yml
@@ -1,0 +1,3 @@
+Lint/UselessAccessModifier:
+  ContextCreatingMethods:
+    - projector

--- a/lib/granite/version.rb
+++ b/lib/granite/version.rb
@@ -1,3 +1,3 @@
 module Granite
-  VERSION = '0.9.4'.freeze
+  VERSION = '0.9.5'.freeze
 end

--- a/lib/rubocop-granite.rb
+++ b/lib/rubocop-granite.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+
+require_relative 'rubocop/granite'
+require_relative 'rubocop/granite/inject'
+
+RuboCop::Granite::Inject.defaults!

--- a/lib/rubocop/granite.rb
+++ b/lib/rubocop/granite.rb
@@ -1,0 +1,9 @@
+module RuboCop
+  module Granite
+    PROJECT_ROOT   = Pathname.new(__dir__).parent.parent.expand_path.freeze
+    CONFIG_DEFAULT = PROJECT_ROOT.join('config', 'rubocop-default.yml').freeze
+    CONFIG         = YAML.safe_load(CONFIG_DEFAULT.read).freeze
+
+    private_constant(:CONFIG_DEFAULT, :PROJECT_ROOT)
+  end
+end

--- a/lib/rubocop/granite/inject.rb
+++ b/lib/rubocop/granite/inject.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# The original code is from https://github.com/rubocop-hq/rubocop-rspec/blob/master/lib/rubocop/rspec/inject.rb
+# See https://github.com/rubocop-hq/rubocop-rspec/blob/master/MIT-LICENSE.md
+module RuboCop
+  module Granite
+    # Because RuboCop doesn't yet support plugins, we have to monkey patch in a
+    # bit of our configuration.
+    module Inject
+      def self.defaults!
+        path = CONFIG_DEFAULT.to_s
+        hash = ConfigLoader.load_file(path)
+        config = Config.new(hash, path).tap(&:make_excludes_absolute)
+        puts "configuration from #{path}" if ConfigLoader.debug?
+        config = ConfigLoader.merge_with_default(config, path)
+        ConfigLoader.instance_variable_set(:@default_configuration, config)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add Rubocop config file that can be required in project using granite. This config adjusts `Lint/UselessAccessModifier` cop to ignore `projector` context.

The implementation of code merging rubocop configs was based on other similar gems.

In project using granite you need to add this in `.rubocop.yml`:

```yaml
require:
  - rubocop-granite
```

### Review

- [x] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [x] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Squash related commits together.
