### PR TITLE
Add domain and description methods to document action

### DIFF
--- a/lib/granite/action.rb
+++ b/lib/granite/action.rb
@@ -11,6 +11,7 @@ require 'granite/action/preconditions'
 require 'granite/action/policies'
 require 'granite/action/projectors'
 require 'granite/action/subject'
+require 'granite/action/documentation'
 
 module Granite
   class Action
@@ -44,6 +45,7 @@ module Granite
     include Preconditions
     include Policies
     include Projectors
+    include Documentation
     prepend AssignAttributes
 
     handle_exception ActiveRecord::RecordInvalid do |e|

--- a/lib/granite/action/documentation.rb
+++ b/lib/granite/action/documentation.rb
@@ -1,0 +1,35 @@
+module Granite
+  class Action
+    # Documentation module is used to categorize Actions by domains and provide a short description of what Action does
+    module Documentation
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :_domain, :_description
+      end
+
+      module ClassMethods
+        # Use domain and description methods to provide information about what Action does and it's domain:
+        #
+        # class Action < Granite::Action
+        #   domain 'library'
+        #   description 'Allows to borrow a book'
+        # end
+
+        # Assign action to domain
+        # @param domain name [String]
+        def domain(domain)
+          self._domain = domain
+        end
+
+        # Provide a short description to the action
+        # @param description name [String]
+        def description(description)
+          self._description = description
+        end
+
+        alias desc description
+      end
+    end
+  end
+end

--- a/lib/granite/action/documentation.rb
+++ b/lib/granite/action/documentation.rb
@@ -9,7 +9,7 @@ module Granite
       end
 
       module ClassMethods
-        # Use domain and description methods to provide information about what Action does and it's domain:
+        # Use domain and description methods to provide information about what Action does and its domain:
         #
         # class Action < Granite::Action
         #   domain 'library'

--- a/spec/lib/granite/action/documentation_spec.rb
+++ b/spec/lib/granite/action/documentation_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Granite::Action::Documentation do
+  before do
+    stub_class(:action, Granite::Action) do
+      domain 'library'
+      desc 'Allows to borrow a book'
+    end
+  end
+
+  specify do
+    expect(Action._domain).to eq('library')
+    expect(Action._description).to eq('Allows to borrow a book')
+  end
+end


### PR DESCRIPTION
This PR introduces `domain` and `description` (`desc`) methods to the `Action` to help better understand what the action does and what domain it belongs to.

```
class Action < Granite::Action
  domain 'library'
  description 'Allows to borrow a book'
end
```

### Review

- [x] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Squash related commits together.
