### PR TITLE
Use respond_to? to check if reference responds to writer when using represents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master (not released yet)
 
+# Version 0.9.7
+
+* fix `represents` to skip not defined attributes on the reference
+
 # Version 0.9.6
 
 * fix gemspec to include `config` directory

--- a/lib/granite/represents/attribute.rb
+++ b/lib/granite/represents/attribute.rb
@@ -11,9 +11,7 @@ module Granite
       end
 
       def sync
-        return if reference.nil?
-
-        reference.public_send(writer, read)
+        reference.public_send(writer, read) if reference.respond_to?(writer)
       end
 
       def typecast(value)

--- a/lib/granite/version.rb
+++ b/lib/granite/version.rb
@@ -1,3 +1,3 @@
 module Granite
-  VERSION = '0.9.6'.freeze
+  VERSION = '0.9.7'.freeze
 end

--- a/spec/lib/granite/represents/attribute_spec.rb
+++ b/spec/lib/granite/represents/attribute_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Granite::Represents::Attribute do
       expect { subject.sync }.to change { action.user.sign_in_count }.from(1).to(2)
     end
 
-    context 'when represents attribute of nil' do
+    context 'when represented object does not respond to attribute name' do
       before do
         stub_class(:action, Granite::Action) do
           allow_if { true }
@@ -80,6 +80,7 @@ RSpec.describe Granite::Represents::Attribute do
           represents :related_ids, of: :user
 
           def user
+            Object.new
           end
         end
       end


### PR DESCRIPTION
Uses `respond_to?` to check if we can set the attribute on `reference`. Useful when `reference` can be of multiple types.

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
