### PR TITLE
Upgrading granite to work with Ruby 3

### DIFF
--- a/lib/granite/routing/mapper.rb
+++ b/lib/granite/routing/mapper.rb
@@ -5,8 +5,8 @@ module Granite
   module Routing
     module Mapper
       def granite(projector_path, **options)
-        route = Route.new(projector_path, options.extract!(:path, :as, :projector_prefix))
-        Declarer.declare(self, route, options)
+        route = Route.new(projector_path, **options.extract!(:path, :as, :projector_prefix))
+        Declarer.declare(self, route, **options)
       end
     end
   end


### PR DESCRIPTION
We are using Ruby 3 in RTI, and without this upgrade, it fails to tie the webhook to the router.

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
