### PR TITLE
Add notifications when action is performed and perform_action matcher based on them

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -85,3 +85,12 @@ Run the action using `perform!` to test side-effects:
 specify { expect { perform! }.to change(User, :count).by(1) }
 ```
 
+<h3 id="testing-composition">Testing action is performed from another Action</h3>
+
+Run the action using `perform!` to test side-effects:
+
+```ruby
+it { expect { perform! }.to perform_action(MyAction) }
+it { expect { perform! }.to perform_action(MyAction).as(performer).with(user: user).using(:try_perform!) }
+```
+

--- a/lib/granite/action.rb
+++ b/lib/granite/action.rb
@@ -5,6 +5,7 @@ require 'active_support/callbacks'
 
 require 'granite/action/types'
 require 'granite/action/error'
+require 'granite/action/instrumentation'
 require 'granite/action/performing'
 require 'granite/action/performer'
 require 'granite/action/precondition'
@@ -48,6 +49,7 @@ module Granite
     include Policies
     include Projectors
     prepend AssignAttributes
+    prepend Instrumentation
 
     handle_exception ActiveRecord::RecordInvalid do |e|
       merge_errors(e.record.errors)

--- a/lib/granite/action/instrumentation.rb
+++ b/lib/granite/action/instrumentation.rb
@@ -1,0 +1,23 @@
+module Granite
+  class Action
+    module Instrumentation
+      def perform!(*, **)
+        instrument_perform(:perform!) { super }
+      end
+
+      def perform(*, **)
+        instrument_perform(:perform) { super }
+      end
+
+      def try_perform!(*, **)
+        instrument_perform(:try_perform!) { super }
+      end
+
+      private
+
+      def instrument_perform(using, &block)
+        ActiveSupport::Notifications.instrument('granite.perform_action', action: self, using: using, &block)
+      end
+    end
+  end
+end

--- a/lib/granite/rspec.rb
+++ b/lib/granite/rspec.rb
@@ -1,5 +1,6 @@
 require 'granite/rspec/action_helpers'
 require 'granite/rspec/have_projector'
+require 'granite/rspec/perform_action'
 require 'granite/rspec/projector_helpers'
 require 'granite/rspec/raise_validation_error'
 require 'granite/rspec/satisfy_preconditions'

--- a/lib/granite/rspec/perform_action.rb
+++ b/lib/granite/rspec/perform_action.rb
@@ -1,0 +1,89 @@
+RSpec::Matchers.define :perform_action do |klass|
+  chain :using do |using|
+    @using = using
+  end
+
+  chain :as do |performer|
+    @performer = performer
+  end
+
+  chain :with do |attributes|
+    @attributes = attributes
+  end
+
+  match do |block|
+    @klass = klass
+    @using ||= :perform!
+
+    @payloads = []
+    subscriber = ActiveSupport::Notifications.subscribe('granite.perform_action') do |_, _, _, _, payload|
+      @payloads << payload
+    end
+
+    block.call
+
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+
+    @payloads.detect { |payload| action_matches?(payload[:action]) && payload[:using] == @using }
+  end
+
+  failure_message do
+    output = "expected to call #{performed_entity}"
+    add_performer_message(output, @performer) if defined?(@performer)
+    add_attributes_message(output, @attributes) if defined?(@attributes)
+
+    similar_payloads = @payloads.select { |payload| class_matches?(payload[:action]) && payload[:using] == @using }
+    if similar_payloads.present?
+      output << "\nreceived calls to #{performed_entity}:"
+      similar_payloads.each { |payload| add_message_from_payload(output, payload) }
+    end
+
+    output
+  end
+
+  failure_message_when_negated do
+    "expected not to call #{performed_entity}"
+  end
+
+  supports_block_expectations
+
+  private
+
+  def add_message_from_payload(output, payload)
+    action = payload[:action]
+    add_performer_message(output, action.performer) if defined?(@performer)
+    add_attributes_message(output, actual_attributes(action)) if defined?(@attributes)
+  end
+
+  def add_performer_message(output, performer)
+    output << "\n    AS #{performer.inspect}"
+  end
+
+  def add_attributes_message(output, attributes)
+    output << "\n    WITH #{attributes.inspect}"
+  end
+
+  def performed_entity
+    "#{@klass}##{@using}"
+  end
+
+  def actual_attributes(action)
+    @attributes.keys.to_h { |attr| [attr, action.public_send(attr)] }
+  end
+
+  def action_matches?(action)
+    class_matches?(action) && performer_matches?(action) && attributes_match?(action)
+  end
+
+  def class_matches?(action)
+    action.is_a?(@klass)
+  end
+
+  def performer_matches?(action)
+    !defined?(@performer) || action.performer == @performer
+  end
+
+  def attributes_match?(action)
+    !defined?(@attributes) || match(@attributes).matches?(actual_attributes(action))
+  end
+end

--- a/spec/lib/granite/action/instrumentation_spec.rb
+++ b/spec/lib/granite/action/instrumentation_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe Granite::Action::Instrumentation do
+  def collect_payloads
+    [].tap do |payloads|
+      subscriber = ActiveSupport::Notifications.subscribe('granite.perform_action') do |_, _, _, _, payload|
+        payloads << payload
+      end
+
+      yield
+
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+  end
+
+  subject(:action) { DummyAction.new }
+
+  before do
+    stub_class(:DummyAction, Granite::Action) do
+      allow_if { true }
+
+      def execute_perform!(*)
+      end
+    end
+  end
+
+  it { expect(collect_payloads { action.perform! }).to eq([{action: action, using: :perform!}]) }
+  it { expect(collect_payloads { action.perform }).to eq([{action: action, using: :perform}]) }
+  it { expect(collect_payloads { action.try_perform! }).to eq([{action: action, using: :try_perform!}]) }
+end

--- a/spec/lib/granite/rspec/perform_action_spec.rb
+++ b/spec/lib/granite/rspec/perform_action_spec.rb
@@ -1,0 +1,95 @@
+RSpec.describe 'perform_action' do
+  let(:action) { DummyAction.new(user) }
+  let(:other_action) { OtherAction.new }
+  let(:user) { User.create! }
+  let(:other_user) { User.create! }
+
+  before do
+    stub_class(:DummyAction, Granite::Action) do
+      allow_if { true }
+      subject :user
+
+      def execute_perform!(*)
+      end
+    end
+
+    stub_class(:OtherAction, Granite::Action) do
+      allow_if { true }
+
+      def execute_perform!(*)
+      end
+    end
+  end
+
+  it { expect { action.perform! }.to perform_action(DummyAction) }
+  it { expect { other_action.perform! }.not_to perform_action(DummyAction) }
+
+  describe 'failures' do
+    it do
+      expect do
+        expect { action.perform! }.not_to perform_action(DummyAction)
+      end.to fail_with('expected not to call DummyAction#perform!')
+    end
+
+    it do
+      expect do
+        expect { other_action.perform! }.to perform_action(DummyAction)
+      end.to fail_with('expected to call DummyAction#perform!')
+    end
+  end
+
+  describe '#using' do
+    it { expect { action.try_perform! }.to perform_action(DummyAction).using(:try_perform!) }
+    it { expect { action.perform }.to perform_action(DummyAction).using(:perform) }
+
+    it do
+      expect do
+        expect { action.perform! }.to perform_action(DummyAction).using(:perform)
+      end.to fail_with('expected to call DummyAction#perform')
+    end
+  end
+
+  describe '#as' do
+    it { expect { action.perform! }.to perform_action(DummyAction).as(nil) }
+
+    it do
+      expect do
+        expect { action.perform! }.to perform_action(DummyAction).as(user)
+      end.to fail_with(<<~MESSAGE.strip)
+        expected to call DummyAction#perform!
+            AS #{user.inspect}
+        received calls to DummyAction#perform!:
+            AS nil
+      MESSAGE
+    end
+  end
+
+  describe '#with' do
+    it { expect { action.perform! }.to perform_action(DummyAction).with(subject: user) }
+
+    it { expect { action.perform! }.to perform_action(DummyAction).with(subject: kind_of(User)) }
+
+    it do
+      expect do
+        expect { action.perform! }.to perform_action(DummyAction).with(subject: other_user)
+      end.to fail_with(<<~MESSAGE.strip)
+        expected to call DummyAction#perform!
+            WITH #{{subject: other_user}.inspect}
+        received calls to DummyAction#perform!:
+            WITH #{{subject: user}.inspect}
+      MESSAGE
+    end
+
+    it do
+      kind_of_matcher = kind_of(String)
+      expect do
+        expect { action.perform! }.to perform_action(DummyAction).with(subject: kind_of_matcher)
+      end.to fail_with(<<~MESSAGE.strip)
+        expected to call DummyAction#perform!
+            WITH #{{subject: kind_of_matcher}.inspect}
+        received calls to DummyAction#perform!:
+            WITH #{{subject: user}.inspect}
+      MESSAGE
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,10 @@ RSpec.configure do |config|
   end
 
   config.include RSpec::Matchers::FailMatchers, file_path: %r{spec/lib/granite/rspec/}
+
+  config.expect_with :rspec do |c|
+    c.max_formatted_output_length = nil
+  end
 end
 
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }


### PR DESCRIPTION
Notifications allow a better way to find out when actions are performed. It enables things like logging when action is performed, collecting metrics how long each perform takes & this new `perform_action` matcher to simplify unit testing of actions.

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
