### PR TITLE
Separate data assignment from validations

### DIFF
--- a/lib/granite/action.rb
+++ b/lib/granite/action.rb
@@ -13,6 +13,7 @@ require 'granite/action/policies'
 require 'granite/action/projectors'
 require 'granite/action/subject'
 require 'granite/action/translations'
+require 'granite/action/assign_data'
 
 module Granite
   class Action
@@ -44,6 +45,7 @@ module Granite
     include Performing
     include Subject
     include Performer
+    include AssignData
     include Preconditions
     include Policies
     include Projectors

--- a/lib/granite/action/assign_data.rb
+++ b/lib/granite/action/assign_data.rb
@@ -1,0 +1,28 @@
+module Granite
+  class Action
+    module AssignData
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :data_assignments
+        self.data_assignments = []
+      end
+
+      module ClassMethods
+        def assign_data(*methods, &block)
+          self.data_assignments += [*methods, *block]
+        end
+      end
+
+      private
+
+      def run_validations!
+        assign_data && super
+      end
+
+      def assign_data
+        data_assignments.each(&method(:evaluate))
+      end
+    end
+  end
+end

--- a/lib/granite/represents.rb
+++ b/lib/granite/represents.rb
@@ -13,10 +13,7 @@ module Granite
         fields.each do |field|
           add_attribute Granite::Represents::Reflection, field, options, &block
 
-          before_validation do
-            attribute(field).sync if attribute(field).changed?
-            true
-          end
+          assign_data { attribute(field).sync if attribute(field).changed? }
         end
       end
     end

--- a/spec/lib/granite/action/assign_data_spec.rb
+++ b/spec/lib/granite/action/assign_data_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Granite::Action::AssignData do
+  subject(:action) { DummyAction.new(user) }
+  let!(:user) { User.create! }
+
+  before do
+    stub_class(:dummy_action, Granite::Action) do
+      subject :user
+    end
+  end
+
+  context 'when using block with assign data' do
+    before do
+      DummyAction.assign_data do
+        user.full_name = 'New Name'
+      end
+    end
+
+    it { expect { action.validate }.to change { user.full_name }.to('New Name') }
+  end
+
+  context 'when using method name with assign data' do
+    before do
+      DummyAction.class_eval do
+        assign_data :set_name
+
+        def set_name
+          user.full_name = 'New Name'
+        end
+      end
+    end
+
+    it { expect { action.validate }.to change { user.full_name }.to('New Name') }
+  end
+end

--- a/spec/lib/granite/represents/reflection_spec.rb
+++ b/spec/lib/granite/represents/reflection_spec.rb
@@ -21,9 +21,7 @@ RSpec.describe Granite::Represents::Reflection do
       let(:instance) { Target.new }
 
       before do
-        stub_class(:target, Object) do
-          include Granite::Base
-
+        stub_class(:target, Granite::Action) do
           references_one :author, class_name: 'DummyUser'
           attribute :field, Object
           represents :field, of: :author
@@ -45,9 +43,7 @@ RSpec.describe Granite::Represents::Reflection do
       let(:instance) { Target.new }
 
       before do
-        stub_class(:target, Object) do
-          include Granite::Base
-
+        stub_class(:target, Granite::Action) do
           references_one :author, default: {}, class_name: 'DummyUser'
           attribute :field, Object
           represents :field, of: :author


### PR DESCRIPTION
This makes data assignment step more explicit & not necessarily part of validation. Data assignment can now be called explicitly if needed. In addition this makes composing multiple actions easier since all actions can finish their data setup before we start validating things.

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
