### PR TITLE
Fix blank action_path

### DIFF
--- a/lib/granite/dispatcher.rb
+++ b/lib/granite/dispatcher.rb
@@ -44,11 +44,11 @@ class Granite::Dispatcher
     ]
   end
 
-  memoize def action_name(request_method_symbol, granite_action, granite_projector, projector_action = '')
+  memoize def action_name(request_method_symbol, granite_action, granite_projector, projector_action)
     projector = projector(granite_action, granite_projector)
     return unless projector
 
-    projector.action_for(request_method_symbol, projector_action)
+    projector.action_for(request_method_symbol, projector_action.to_s)
   end
 
   memoize def projector(granite_action, granite_projector)

--- a/spec/lib/granite/dispatcher_spec.rb
+++ b/spec/lib/granite/dispatcher_spec.rb
@@ -78,6 +78,17 @@ RSpec.describe Granite::Dispatcher do
 
       expect(controller_action).to have_received(:call).with(env)
     end
+
+    context 'when projector action is nil' do
+      let(:params) { super().except(:projector_action) }
+      let(:request_method) { :post }
+
+      it 'finds the controller action by name in the specified projector' do
+        subject.serve(req)
+
+        expect(controller_class).to have_received(:action).with(:perform)
+      end
+    end
   end
 
   describe '#controller' do


### PR DESCRIPTION
Fixes `get :confirm, as: ''` controller actions not working. 

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
