### PR TITLE
Fix represents with default: false not seeing any changes in model

### DIFF
--- a/lib/granite/represents/attribute.rb
+++ b/lib/granite/represents/attribute.rb
@@ -34,7 +34,7 @@ module Granite
       end
 
       def changed?
-        if reflection.options[:default].present?
+        if reflection.options.key?(:default)
           reference.public_send(reader) != read
         else
           owner.public_send("#{name}_changed?")

--- a/spec/lib/granite/represents/attribute_spec.rb
+++ b/spec/lib/granite/represents/attribute_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Granite::Represents::Attribute do
 
       attribute :sign_in_count, Integer, default: '1'
       attribute :created_at, Time
+      attribute :has_signed_in, Boolean
     end
 
     stub_class(:action, Granite::Action) do
@@ -17,6 +18,7 @@ RSpec.describe Granite::Represents::Attribute do
 
       represents :sign_in_count, of: :user
       represents :created_at, default: -> { '2000-10-10' }, of: :user
+      represents :has_signed_in, default: false, of: :user
       represents :related_ids, of: :user
 
       def user
@@ -270,6 +272,16 @@ RSpec.describe Granite::Represents::Attribute do
       specify do
         expect(subject.owner.user).to receive(:created_at)
         expect(subject.owner).not_to receive(:created_at_changed?)
+        expect(subject).to be_changed
+      end
+    end
+
+    context 'when attribute has false as default value' do
+      subject { action.attribute(:has_signed_in) }
+
+      specify do
+        expect(subject.owner.user).to receive(:has_signed_in)
+        expect(subject.owner).not_to receive(:has_signed_in_changed?)
         expect(subject).to be_changed
       end
     end


### PR DESCRIPTION
`represents :attribute, default: false` would rely on user to provide value to consider the attribute changed. Since we only sync attributes that are changed, it means that:
```ruby
class MyAction < Granite::Action
  subject :user
  represents :has_signed_in, of: :user, default: false
end

user = User.new(has_signed_in: nil)
MyAction.new(user).perform!
user.has_signed_in #=> nil
```

Even though `default` is `false`, granite doesn't see any changes in `has_signed_in` attribute, so it doesn't set it to `false`. This fixes the issue, and now after action is performed:

```ruby
user.has_signed_in #=> false
```

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
