### PR TITLE
Document Dependency Injection

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -370,7 +370,7 @@ Prefer this way over custom exception handling in private methods.
 ### Dependency Injection
 
 Granite assigns attributes in Action's `#initialize` method based on parameters that are passed to the initializer.
-However, we can still manually inject dependencies.
+However, you can still use custom initializers for Granite actions when you don't want to use attributes, for example when using Dependency Injection:
 
 ```ruby
 class Action < Granite::Action

--- a/docs/index.md
+++ b/docs/index.md
@@ -367,6 +367,27 @@ Adding errors to action object is important, because each time a handled excepti
 Validation exception will have the same backtrace as original error.
 Prefer this way over custom exception handling in private methods.
 
+### Dependency Injection
+
+Granite uses action initializer for attributes.
+However, we can still manually inject dependencies.
+
+```ruby
+class Action < Granite::Action
+  attribute :name, String
+
+  private attr_reader :my_dep
+
+  def initialize(*args, my_dep: Foo.new, **kwargs, &block)
+    @my_dep = my_dep
+    super(*args, **kwargs, &block)
+  end
+end
+
+Action.new(name: "Jane")                  # uses default value for `my_dep'
+Action.new(name: "Jane", my_dep: Bar.new) # uses custom value for `my_dep'
+```
+
 ### I18n
 
 There are special I18n rules working in action. If I18n identifier is prefixed with `.` (`t('.foobar')`) - then translations lookup happens in following order:

--- a/docs/index.md
+++ b/docs/index.md
@@ -369,7 +369,7 @@ Prefer this way over custom exception handling in private methods.
 
 ### Dependency Injection
 
-Granite uses action initializer for attributes.
+Granite assigns attributes in Action's `#initialize` method based on parameters that are passed to the initializer.
 However, we can still manually inject dependencies.
 
 ```ruby

--- a/spec/lib/granite/action_spec.rb
+++ b/spec/lib/granite/action_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Granite::Action do
         attr_reader :my_dep, :another_dep
         private :my_dep, :another_dep
 
-        def initialize(*args, my_dep: Hash[a: 1], another_dep: 'Foo', **kwargs, &block)
+        def initialize(*args, my_dep: {a: 1}, another_dep: 'Foo', **kwargs, &block)
           @my_dep = my_dep
           @another_dep = another_dep
           super(*args, **kwargs, &block)

--- a/spec/lib/granite/action_spec.rb
+++ b/spec/lib/granite/action_spec.rb
@@ -7,44 +7,6 @@ RSpec.describe Granite::Action do
     end
   end
 
-  describe 'Dependency Injection' do
-    before do
-      stub_class(:action, Granite::Action) do
-        allow_if { true }
-
-        attribute :comment, String
-
-        attr_reader :my_dep, :another_dep
-        private :my_dep, :another_dep
-
-        def initialize(*args, my_dep: {a: 1}, another_dep: 'Foo', **kwargs, &block)
-          @my_dep = my_dep
-          @another_dep = another_dep
-          super(*args, **kwargs, &block)
-        end
-      end
-
-      stub_class(:another_action, Granite::Action) do
-        allow_if { true }
-      end
-    end
-
-    it 'uses custom value' do
-      action = Action.new(comment: 'blah blah blah', my_dep: Array(1))
-      expect(action.__send__(:my_dep)).to be_kind_of(Array)
-    end
-
-    it 'protects from mass assigment of attributes' do
-      expect(ActiveData.config.logger).to receive(:info).with(/Ignoring undefined `foo` attribute value/)
-      Action.new(foo: 'bar')
-    end
-
-    it 'does not assign dependencies to other actions' do
-      another = AnotherAction.new
-      expect { another.__send__(:my_dep) }.to raise_error(NoMethodError, /undefined method `my_dep'/)
-    end
-  end
-
   describe '.i18n_scope' do
     specify { expect(Action.i18n_scope).to eq :granite_action }
   end

--- a/spec/lib/granite/action_spec.rb
+++ b/spec/lib/granite/action_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Granite::Action do
 
         attribute :comment, String
 
-        private attr_reader :my_dep, :another_dep
+        attr_reader :my_dep, :another_dep
+        private :my_dep, :another_dep
 
         def initialize(*args, my_dep: Hash[a: 1], another_dep: "Foo", **kwargs, &block)
           @my_dep = my_dep

--- a/spec/lib/granite/action_spec.rb
+++ b/spec/lib/granite/action_spec.rb
@@ -29,17 +29,6 @@ RSpec.describe Granite::Action do
       end
     end
 
-    it 'creates private getter' do
-      action = Action.new(comment: 'blah blah blah')
-      expect { action.my_dep }.to raise_error(NoMethodError, /private method `my_dep' called/)
-    end
-
-    it 'uses default value' do
-      action = Action.new(comment: 'blah blah blah')
-      expect(action.__send__(:my_dep)).to be_kind_of(Hash)
-      expect(action.__send__(:another_dep)).to be_kind_of(String)
-    end
-
     it 'uses custom value' do
       action = Action.new(comment: 'blah blah blah', my_dep: Array(1))
       expect(action.__send__(:my_dep)).to be_kind_of(Array)

--- a/spec/lib/granite/action_spec.rb
+++ b/spec/lib/granite/action_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Granite::Action do
         attr_reader :my_dep, :another_dep
         private :my_dep, :another_dep
 
-        def initialize(*args, my_dep: Hash[a: 1], another_dep: "Foo", **kwargs, &block)
+        def initialize(*args, my_dep: Hash[a: 1], another_dep: 'Foo', **kwargs, &block)
           @my_dep = my_dep
           @another_dep = another_dep
           super(*args, **kwargs, &block)


### PR DESCRIPTION
Document how to use Dependency Injection with Granite.

### Principles

#### Attributes

  * I want to avoid attributes to setup dependencies.
  * Mixing the two concepts is problematic as input (attributes) is a different concept than dependencies (e.g. a logger).

#### Specs

  * The specs are testing basic Ruby behavior.
  * But we’re NOT testing a basic Ruby object, we’re testing a Granite Action.
  * Granite Actions have attributes that handle getter and setters. I want to assert that it’s still possible to expose custom getters, without active_data to get on my way.
  * Those specs are trivial, but meant to prevent regressions: if we change attributes internals, we don’t accidentally override those behaviors.
  * These specs guarantee that documentation is up to date

### Review

- [x] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Squash related commits together.