### PR TITLE
Handle parametrized error messages in preconditions

### DIFF
--- a/lib/granite/action/preconditions.rb
+++ b/lib/granite/action/preconditions.rb
@@ -98,8 +98,8 @@ module Granite
       end
 
       # Adds passed error message and options to `errors` object
-      def decline_with(*args)
-        errors.add(:base, *args)
+      def decline_with(*args, **kwargs)
+        errors.add(:base, *args, **kwargs)
         failed_preconditions << args.first
       end
 

--- a/spec/lib/granite/action/performing_spec.rb
+++ b/spec/lib/granite/action/performing_spec.rb
@@ -64,12 +64,12 @@ RSpec.describe Granite::Action::Performing do
     let(:action) { Action.new(user: user, login: 'Login') }
 
     specify do
-      expect { expect(action.perform).to eq(false) }
+      expect { expect(action.perform).to be(false) }
         .to change { action.errors.messages }.to(base: ['Dummy exception'])
         .and not_change { user.reload.email }
     end
 
-    specify { expect(action.perform(some_value: 'value')).to eq(false) }
+    specify { expect(action.perform(some_value: 'value')).to be(false) }
 
     specify do
       expect { action.perform! }
@@ -110,7 +110,7 @@ RSpec.describe Granite::Action::Performing do
         allow(ActiveData.config.logger).to receive(:info)
       end
 
-      specify { expect(action.perform).to eq(false) }
+      specify { expect(action.perform).to be(false) }
       specify { expect { action.perform }.to change { action.errors.messages }.to('skills.0.name': ["can't be blank"]) }
       specify { expect { action.perform }.not_to change { user.reload.email } }
     end
@@ -118,7 +118,7 @@ RSpec.describe Granite::Action::Performing do
     context 'without login' do
       let(:action) { Action.new(user) }
 
-      specify { expect(action.perform).to eq(false) }
+      specify { expect(action.perform).to be(false) }
       specify { expect { action.perform }.to change { action.errors.messages }.to(email: ["can't be blank"]) }
       specify { expect { action.perform }.not_to change { user.reload.email } }
     end
@@ -126,7 +126,7 @@ RSpec.describe Granite::Action::Performing do
     context 'with empty login' do
       let(:action) { Action.new(user, login: '') }
 
-      specify { expect(action.perform).to eq(false) }
+      specify { expect(action.perform).to be(false) }
       specify { expect { action.perform }.to change { action.errors.messages }.to(base: ['Base error message']) }
       specify { expect { action.perform }.not_to change { user.reload.email } }
     end
@@ -151,7 +151,7 @@ RSpec.describe Granite::Action::Performing do
       end
 
       let(:action) { Action.new }
-      specify { expect(action.perform).to eq(true) }
+      specify { expect(action.perform).to be(true) }
     end
 
     describe 'validation contexts' do
@@ -169,7 +169,7 @@ RSpec.describe Granite::Action::Performing do
         context 'with invalid data for the :user context' do
           let(:action) { Action.new(user, login: 'Foo Bar') }
 
-          specify { is_expected.to eq(false) }
+          specify { is_expected.to be(false) }
           specify { expect { subject }.to change { action.errors.messages }.to(login: ['is invalid']) }
           specify { expect { subject }.not_to change { user.reload.email } }
         end
@@ -261,7 +261,7 @@ RSpec.describe Granite::Action::Performing do
       end
 
       let(:action) { Action.new }
-      specify { expect(action.perform!).to eq(true) }
+      specify { expect(action.perform!).to be(true) }
     end
 
     describe 'validation contexts' do
@@ -371,7 +371,7 @@ RSpec.describe Granite::Action::Performing do
       end
 
       let(:action) { Action.new }
-      specify { expect(action.try_perform!).to eq(true) }
+      specify { expect(action.try_perform!).to be(true) }
     end
 
     context 'when transaction is called only once' do

--- a/spec/lib/granite/action/policies/always_allow_strategy_spec.rb
+++ b/spec/lib/granite/action/policies/always_allow_strategy_spec.rb
@@ -3,6 +3,6 @@ RSpec.describe Granite::Action::Policies::AlwaysAllowStrategy do
     subject { described_class.allowed?(action) }
     let(:action) { instance_double('Granite::Action') }
 
-    it { is_expected.to eq true }
+    it { is_expected.to be(true) }
   end
 end

--- a/spec/lib/granite/action/policies/any_strategy_spec.rb
+++ b/spec/lib/granite/action/policies/any_strategy_spec.rb
@@ -5,22 +5,22 @@ RSpec.describe Granite::Action::Policies::AnyStrategy do
     let(:policies) { [] }
 
     context 'when action has no policies defined' do
-      it { is_expected.to eq false }
+      it { is_expected.to be(false) }
     end
 
     context 'when action has at least one "true" policy' do
       let(:policies) { [proc { false }, proc { true }, proc { false }] }
-      it { is_expected.to eq true }
+      it { is_expected.to be(true) }
     end
 
     context 'when action has all policies evaled to true' do
       let(:policies) { [proc { true }, proc { true }] }
-      it { is_expected.to eq true }
+      it { is_expected.to be(true) }
     end
 
     context 'when action has all policies evaled to false' do
       let(:policies) { [proc { false }, proc { false }] }
-      it { is_expected.to eq false }
+      it { is_expected.to be(false) }
     end
   end
 end

--- a/spec/lib/granite/action/policies/required_performer_strategy_spec.rb
+++ b/spec/lib/granite/action/policies/required_performer_strategy_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Granite::Action::Policies::RequiredPerformerStrategy do
 
     context 'when performer is present' do
       let(:performer) { 'performer' }
-      it { is_expected.to eq true }
+      it { is_expected.to be(true) }
     end
 
     context 'when performer is not persent' do
-      it { is_expected.to eq false }
+      it { is_expected.to be(false) }
     end
   end
 end

--- a/spec/lib/granite/action/policies_spec.rb
+++ b/spec/lib/granite/action/policies_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Granite::Action::Policies do
   end
 
   describe '#perform' do
-    specify { expect(Action.as(Student.new).new.perform).to eq(true) }
+    specify { expect(Action.as(Student.new).new.perform).to be(true) }
 
     specify do
       expect { Action.as(Teacher.new).new.perform }.to raise_error(
@@ -51,7 +51,7 @@ RSpec.describe Granite::Action::Policies do
 
       let(:student) { Student.new }
 
-      specify { expect(Action.as(student).new(student).perform).to eq(true) }
+      specify { expect(Action.as(student).new(student).perform).to be(true) }
       specify { expect { Action.as(Student.new).new(student).perform }.to raise_error Granite::Action::NotAllowedError }
       specify { expect { Action.as(Teacher.new).new(student).perform }.to raise_error Granite::Action::NotAllowedError }
     end

--- a/spec/lib/granite/action/precondition_spec.rb
+++ b/spec/lib/granite/action/precondition_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Granite::Action::Precondition do
     specify do
       expect(action).to receive(:title).and_call_original
 
-      expect(precondition.call(expected_title: 'Ruby')).to eq(true)
+      expect(precondition.call(expected_title: 'Ruby')).to be(true)
     end
   end
 end

--- a/spec/lib/granite/action/preconditions_spec.rb
+++ b/spec/lib/granite/action/preconditions_spec.rb
@@ -3,9 +3,11 @@ RSpec.describe Granite::Action::Preconditions do
     before do
       stub_class(:action, Granite::Action) do
         attribute :title, String
+        attribute :author, String
 
         precondition do
           decline_with(:wrong_title) if title !~ /Ruby/
+          decline_with(:wrong_author, author_name: author) if author && author != 'George Orwell'
         end
         # Just to check that validations are not run if preconditions are not satisfied
         validates :title, inclusion: {in: ['Ruby']}
@@ -54,6 +56,15 @@ RSpec.describe Granite::Action::Preconditions do
         let(:action) { Action.new(title: 'Ruby') }
         specify do
           expect { action.valid? }.not_to change { action.errors.messages }
+        end
+      end
+
+      context 'with wrong Author' do
+        let(:action) { Action.new(title: 'Ruby', author: 'Vladimir Sorokin') }
+
+        specify do
+          expect { action.valid? }.to change { action.errors.messages }
+            .to(base: ['George Orwell is the only acceptable author, Vladimir Sorokin is not'])
         end
       end
     end

--- a/spec/lib/granite/action/transaction_manager_spec.rb
+++ b/spec/lib/granite/action/transaction_manager_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Granite::Action::TransactionManager do
         it 'returns false and does not trigger callbacks' do
           expect(object_listener).not_to receive(:run_callbacks)
           expect(block_listener).not_to receive(:do_stuff)
-          expect(subject).to eq(false)
+          expect(subject).to be(false)
         end
       end
 

--- a/spec/lib/granite/action/transaction_spec.rb
+++ b/spec/lib/granite/action/transaction_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Granite::Action::Transaction do
 
       it 'commits changes of the first action only' do
         expect do
-          expect(Action1.new.perform!).to eq true
+          expect(Action1.new.perform!).to be(true)
         end.to change { User.count }.by(2).and not_change { Role.count }
       end
     end

--- a/spec/lib/granite/dispatcher_spec.rb
+++ b/spec/lib/granite/dispatcher_spec.rb
@@ -29,19 +29,19 @@ RSpec.describe Granite::Dispatcher do
     let(:request_method) { :get }
 
     context 'when BA projector has appropriate action defined' do
-      it { is_expected.to eq true }
+      it { is_expected.to be(true) }
     end
 
     context 'when request has different request method' do
       let(:request_method) { :post }
 
-      it { is_expected.to eq false }
+      it { is_expected.to be(false) }
     end
 
     context 'when request has different action' do
       let(:params) { super().merge(projector_action: 'undefined') }
 
-      it { is_expected.to eq false }
+      it { is_expected.to be(false) }
     end
 
     context 'when request has invalid granite params' do
@@ -51,7 +51,7 @@ RSpec.describe Granite::Dispatcher do
 
       let(:params) { {granite_action: 'action_without_projectors', granite_projector: 'dummy', projector_action: 'confirm'} }
 
-      it { is_expected.to eq false }
+      it { is_expected.to be(false) }
     end
   end
 
@@ -100,7 +100,7 @@ RSpec.describe Granite::Dispatcher do
 
     context 'when projector does not exist' do
       let(:params) { super().merge(granite_projector: 'invalid') }
-      it { is_expected.to eq nil }
+      it { is_expected.to be_nil }
     end
   end
 

--- a/spec/lib/granite/performer_proxy/proxy_spec.rb
+++ b/spec/lib/granite/performer_proxy/proxy_spec.rb
@@ -27,14 +27,14 @@ RSpec.describe Granite::PerformerProxy::Proxy do
 
   describe '#respond_to_missing?' do
     specify 'when class does not respond to a method' do
-      expect(subject.__send__(:respond_to_missing?, :func)).to eq false
+      expect(subject.__send__(:respond_to_missing?, :func)).to be(false)
     end
 
     context 'when klass responds to a method' do
       let(:klass) { class_double('DummyClass', func: 'value') }
 
       specify do
-        expect(subject.__send__(:respond_to_missing?, :func)).to eq true
+        expect(subject.__send__(:respond_to_missing?, :func)).to be(true)
       end
     end
   end

--- a/spec/lib/granite/projector/controller_actions_spec.rb
+++ b/spec/lib/granite/projector/controller_actions_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Granite::Projector::ControllerActions, type: :granite_projector d
 
   describe '.action_for' do
     specify { expect(Projector.action_for(:get, 'confirm')).to eq :confirm }
-    specify { expect(Projector.action_for(:get, 'perform')).to eq nil }
+    specify { expect(Projector.action_for(:get, 'perform')).to be_nil }
     specify { expect(Projector.action_for(:get, '')).to eq :custom }
     specify { expect(Projector.action_for(:post, '')).to eq :custom_post }
 
@@ -60,7 +60,7 @@ RSpec.describe Granite::Projector::ControllerActions, type: :granite_projector d
         end
       end
 
-      specify { expect(Projector.action_for(:get, 'confirm')).to eq nil }
+      specify { expect(Projector.action_for(:get, 'confirm')).to be_nil }
       specify { expect(Projector.action_for(:get, 'test')).to eq :confirm }
     end
   end

--- a/spec/lib/granite/represents/attribute_spec.rb
+++ b/spec/lib/granite/represents/attribute_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Granite::Represents::Attribute do
     end
 
     it 'ignores nil' do
-      expect(subject.typecast(nil)).to eq nil
+      expect(subject.typecast(nil)).to be_nil
     end
   end
 

--- a/spec/lib/granite/routing/cache_spec.rb
+++ b/spec/lib/granite/routing/cache_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Granite::Routing::Cache do
     end
 
     it 'returns nil if no route found' do
-      expect(subject[:foo, :bar]).to eq nil
+      expect(subject[:foo, :bar]).to be_nil
     end
   end
 end

--- a/spec/support/translations.rb
+++ b/spec/support/translations.rb
@@ -11,6 +11,7 @@ I18n.backend.store_translations(:en, YAML.safe_load(<<-YAML))
             base:
               message: 'Base error message'
               wrong_title: 'Wrong title'
+              wrong_author: 'George Orwell is the only acceptable author, %{author_name} is not'
     dummy_action:
       key: 'dummy action key'
       dummy:


### PR DESCRIPTION
Right now we're not passing kwargs/error arguments to the `errors.add`, fix it (second commit)
Also fix `RSpec/BeEq` rubocop offenses with new rubocop-rspec-2.9.0 (first commit)

### Review

- n/a Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [x] Get approval.

### Pre-merge checklist

- ~~[ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.~~
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Squash related commits together.
