### PR TITLE
Drop support for ruby 2.5 and fix rubocop

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - { ruby: '2.5', rails: '5.2' }
           - { ruby: '2.6', rails: '6.0' }
           - { ruby: '2.7', rails: '6.1' }
           - { ruby: '3.0', rails: '7.0' }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
     - 'vendor/bundle/**/*'
     - 'log/**/*'
   DisplayCopNames: true
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   NewCops: enable
 
 Naming/FileName:

--- a/lib/granite/action/transaction_manager.rb
+++ b/lib/granite/action/transaction_manager.rb
@@ -69,7 +69,7 @@ module Granite
 
           return unless collected_errors.any?
 
-          log_errors(collected_errors[1..-1])
+          log_errors(collected_errors[1..])
           fail collected_errors.first
         end
 

--- a/lib/granite/projector/helpers.rb
+++ b/lib/granite/projector/helpers.rb
@@ -35,8 +35,7 @@ Do you have #{projector.action_class.name.underscore}##{projector.projector_name
 
       def required_params
         corresponding_route.required_parts
-          .map { |name| [name, action.public_send(name)] }
-          .to_h
+          .to_h { |name| [name, action.public_send(name)] }
       end
 
       def corresponding_route

--- a/spec/lib/granite/action/performer_spec.rb
+++ b/spec/lib/granite/action/performer_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Granite::Action::Performer do
-  let(:performer1) { instance_double('Performer', id: 5) }
-  let(:performer2) { instance_double('Performer', id: 10) }
+  let(:performer1) { instance_double(User, id: 5) }
+  let(:performer2) { instance_double(User, id: 10) }
 
   before do
     stub_class(:projector, Granite::Projector)

--- a/spec/lib/granite/action/policies/always_allow_strategy_spec.rb
+++ b/spec/lib/granite/action/policies/always_allow_strategy_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Granite::Action::Policies::AlwaysAllowStrategy do
   describe '.allowed?' do
     subject { described_class.allowed?(action) }
-    let(:action) { instance_double('Granite::Action') }
+    let(:action) { instance_double(Granite::Action) }
 
     it { is_expected.to be(true) }
   end

--- a/spec/lib/granite/action/policies/any_strategy_spec.rb
+++ b/spec/lib/granite/action/policies/any_strategy_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Granite::Action::Policies::AnyStrategy do
   describe '.allowed?' do
     subject { described_class.allowed?(action) }
-    let(:action) { instance_double('Granite::Action', _policies: policies, performer: nil) }
+    let(:action) { instance_double(Granite::Action, _policies: policies, performer: nil) }
     let(:policies) { [] }
 
     context 'when action has no policies defined' do

--- a/spec/lib/granite/action/policies/required_performer_strategy_spec.rb
+++ b/spec/lib/granite/action/policies/required_performer_strategy_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Granite::Action::Policies::RequiredPerformerStrategy do
   describe '.allowed?' do
     subject { described_class.allowed?(action) }
-    let(:action) { instance_double('Granite::Action', _policies: [proc { true }], performer: performer) }
+    let(:action) { instance_double(Granite::Action, _policies: [proc { true }], performer: performer) }
     let(:performer) { nil }
 
     context 'when performer is present' do

--- a/spec/lib/granite/dispatcher_spec.rb
+++ b/spec/lib/granite/dispatcher_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Granite::Dispatcher do
 
   describe '#constraints' do
     subject { dispatcher.constraints.all? { |c| c.call(req) } }
-    let(:req) { instance_double('ActionDispatch::Request', env: env, params: params, request_method_symbol: request_method) }
+    let(:req) { instance_double(ActionDispatch::Request, env: env, params: params, request_method_symbol: request_method) }
     let(:env) { {} }
     let(:params) { super().merge(projector_action: 'confirm') }
     let(:request_method) { :get }
@@ -61,7 +61,7 @@ RSpec.describe Granite::Dispatcher do
     let(:env) { {} }
     let(:params) { super().merge(projector_action: 'confirm') }
     let(:request_method) { :get }
-    let(:req) { instance_double('ActionDispatch::Request', env: env, params: params, request_method_symbol: request_method) }
+    let(:req) { instance_double(ActionDispatch::Request, env: env, params: params, request_method_symbol: request_method) }
 
     before do
       allow(controller_class).to receive(:action) { controller_action }

--- a/spec/lib/granite/performer_proxy/proxy_spec.rb
+++ b/spec/lib/granite/performer_proxy/proxy_spec.rb
@@ -5,8 +5,8 @@ require 'granite/performer_proxy/proxy'
 RSpec.describe Granite::PerformerProxy::Proxy do
   subject { described_class.new(klass, performer) }
 
-  let(:klass) { class_double('DummyClass', to_s: 'DummyClass') }
-  let(:performer) { instance_double('Performer', to_s: '#Performer') }
+  let(:klass) { stub_class('DummyClass') }
+  let(:performer) { instance_double(User, to_s: '#Performer') }
 
   its(:inspect) { is_expected.to eq('<DummyClassPerformerProxy #Performer>') }
 
@@ -16,7 +16,9 @@ RSpec.describe Granite::PerformerProxy::Proxy do
     end
 
     context 'when klass responds to a method' do
-      let(:klass) { class_double('DummyClass', func: 'value') }
+      before do
+        klass.define_singleton_method(:func) { |_| 'value' }
+      end
 
       specify do
         expect(klass).to receive(:with_proxy_performer).with(performer).and_yield
@@ -31,7 +33,9 @@ RSpec.describe Granite::PerformerProxy::Proxy do
     end
 
     context 'when klass responds to a method' do
-      let(:klass) { class_double('DummyClass', func: 'value') }
+      before do
+        klass.define_singleton_method(:func) { 'value' }
+      end
 
       specify do
         expect(subject.__send__(:respond_to_missing?, :func)).to be(true)

--- a/spec/lib/granite/performer_proxy_spec.rb
+++ b/spec/lib/granite/performer_proxy_spec.rb
@@ -4,9 +4,17 @@ require 'granite/performer_proxy'
 
 RSpec.describe Granite::PerformerProxy do
   subject { klass.new }
-  let(:klass) { class_double('DummyClass', hash: 'hash').tap { |k| k.include Granite::PerformerProxy } }
-  let(:performer) { instance_double('Performer') }
-  let(:proxy) { instance_double('Granite::PerformerProxy::Proxy') }
+  let(:klass) do
+    Class.new do
+      include Granite::PerformerProxy
+
+      def self.hash
+        'hash'
+      end
+    end
+  end
+  let(:performer) { instance_double(User) }
+  let(:proxy) { instance_double(Granite::PerformerProxy::Proxy) }
 
   describe '.as' do
     before do
@@ -33,6 +41,10 @@ RSpec.describe Granite::PerformerProxy do
   describe '.proxy_performer' do
     before do
       Thread.current[:granite_proxy_performer_hash] = performer
+    end
+
+    after do
+      Thread.current[:granite_proxy_performer_hash] = nil
     end
 
     specify do

--- a/spec/lib/granite/projector_spec.rb
+++ b/spec/lib/granite/projector_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Granite::Projector do
   end
 
   describe '.as' do
-    let(:student) { instance_double('Student') }
+    let(:student) { instance_double(Student) }
     specify { expect(Projector.as(student).new.action.performer).to eq(student) }
   end
 

--- a/spec/lib/granite/routing/cache_spec.rb
+++ b/spec/lib/granite/routing/cache_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe Granite::Routing::Cache do
   subject { described_class.new(routes) }
   let(:action_route) do
-    instance_double('ActionDispatch::Journey::Route', required_defaults: {granite_action: 'test', granite_projector: 'simple'})
+    instance_double(ActionDispatch::Journey::Route, required_defaults: {granite_action: 'test', granite_projector: 'simple'})
   end
   let(:another_action_route) do
-    instance_double('ActionDispatch::Journey::Route', required_defaults: {granite_action: 'test2', granite_projector: 'simple'})
+    instance_double(ActionDispatch::Journey::Route, required_defaults: {granite_action: 'test2', granite_projector: 'simple'})
   end
   let(:regular_route) do
-    instance_double('ActionDispatch::Journey::Route', required_defaults: {})
+    instance_double(ActionDispatch::Journey::Route, required_defaults: {})
   end
   let(:routes) do
     [action_route, another_action_route, regular_route]

--- a/spec/lib/granite_spec.rb
+++ b/spec/lib/granite_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Granite, type: :request do
 
     context 'with project_performer' do
       context 'when user' do
-        let(:performer) { instance_double('performer', id: 'User') }
+        let(:performer) { instance_double(User, id: 'User') }
 
         it 'is allowed' do
           allow_any_instance_of(ApplicationController).to receive(:projector_performer).and_return(performer)
@@ -58,7 +58,7 @@ RSpec.describe Granite, type: :request do
       end
 
       context 'when guest' do
-        let(:performer) { instance_double('performer', id: 'Guest') }
+        let(:performer) { instance_double(User, id: 'Guest') }
 
         it 'is not allowed' do
           allow_any_instance_of(ApplicationController).to receive(:projector_performer).and_return(performer)


### PR DESCRIPTION
Rubocop has dropped support for ruby 2.5. We either need to also drop support support or freeze rubocop to lower version. None of our projects use 2.5 afaik, so I think it makes sense to drop the support.

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
