### PR TITLE
[SCX-X] Add Enum type usage to docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -158,15 +158,29 @@ class CreateBook < Granite::Action
   attribute :name, String
   attribute :year, Integer
   represents :author, of: :book
-  
+
   assign_data :set_name
   assign_data do
     book.year = year
   end
-  
+
   private def assign_name
     book.name = name
   end
+end
+```
+
+#### Enums
+
+When using `represents` with `enum` type in Rails, sometimes the real value type cannot be recognized automatically. You need to specify the real value type:
+
+```ruby
+class Book < ApplicationRecord
+  enum status: [draft: 'draft', published: 'published']
+end
+
+class CreateBook < Granite::Action
+  represents :status, type: String, of: :book
 end
 ```
 


### PR DESCRIPTION
When we use `Granite` with `Enum` type in Rails, we encountered an issue that the value was not assigned to the attribute correctly. After some investigation, we find a workaround that wasn't documented, so we think if it's better to add it to the current doc.

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
