### PR TITLE
Rename `using` to `with`

### DIFF
--- a/app/controllers/granite/controller.rb
+++ b/app/controllers/granite/controller.rb
@@ -17,7 +17,7 @@ module Granite
       @projector ||=
         begin
           projector_class = action_class.public_send(projector_name)
-          projector_class = projector_class.using(projector_context) if respond_to?(:projector_context, true)
+          projector_class = projector_class.with(projector_context) if respond_to?(:projector_context, true)
           projector_class.new(projector_params)
         end
     end

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,13 +118,13 @@ after execute_perform
 
 ### Context & performer
 
-Every BA has a context which is a hash that can be assigned via `.using` class method before BA 
+Every BA has a context which is a hash that can be assigned via `.with` class method before BA 
 initialization. Context is usually used to pass performer of the action which is so common that there
 are methods defined to access & set performer
 `performer` specifically.
 
 ```ruby
-action = MyAction.using(performer: Admin.first).new(params)
+action = MyAction.with(performer: Admin.first).new(params)
 action.ctx #=> #<Granite::ContextProxy::Data performer: Admin.first>
 action.performer #=> Admin.first
 
@@ -133,8 +133,8 @@ action.ctx #=> #<Granite::ContextProxy::Data performer: Admin.first>
 action.performer #=> Admin.first
 ```
  
-If you need more attributes in context of your application, you should override `BaseAction.using` 
-and `BaseProjector.using` methods.
+If you need more attributes in context of your application, you should override `BaseAction.with` 
+and `BaseProjector.with` methods.
 
 ```ruby
 module GraniteContext
@@ -145,7 +145,7 @@ module GraniteContext
     end
   end
 
-  def using(data)
+  def with(data)
     Granite::ContextProxy::Proxy.new(self, BaseAction::ContextData.wrap(data))
   end
 end
@@ -153,7 +153,7 @@ end
 BaseAction.extend GraniteContext
 BaseProjector.extend GraniteContext
 
-BaseAction.using(performer: performer, custom: true)
+BaseAction.with(performer: performer, custom: true)
 ```
 
 ### Attributes

--- a/docs/projectors.md
+++ b/docs/projectors.md
@@ -8,7 +8,7 @@ class MoviesController < ApplicationController
   # Regular controller definition
   # ...
   def create
-    BA::Movies::Create.using(performer: current_user).new(some_params).perform!
+    BA::Movies::Create.with(performer: current_user).new(some_params).perform!
   end
   # ...
 end

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -692,7 +692,7 @@ class InlineProjector < Granite::Projector
   end
 
   def build_action(*args)
-    action_class.using(self.class.proxy_context || {performer: h.current_user}).new(*args)
+    action_class.with(self.class.proxy_context || {performer: h.current_user}).new(*args)
   end
 end
 ```

--- a/lib/granite/context_proxy.rb
+++ b/lib/granite/context_proxy.rb
@@ -10,12 +10,12 @@ module Granite
     module ClassMethods
       PROXY_CONTEXT_KEY = :granite_proxy_context
 
-      def using(data)
+      def with(data)
         Proxy.new(self, Data.wrap(data))
       end
 
       def as(performer)
-        using(performer: performer)
+        with(performer: performer)
       end
 
       def with_context(context)

--- a/lib/granite/context_proxy/data.rb
+++ b/lib/granite/context_proxy/data.rb
@@ -1,6 +1,6 @@
 module Granite
   module ContextProxy
-    # Contains all the arbitrary data that is passed to BA with `using`
+    # Contains all the arbitrary data that is passed to BA with `with`
     class Data
       attr_reader :performer
 

--- a/lib/granite/projector.rb
+++ b/lib/granite/projector.rb
@@ -42,7 +42,7 @@ module Granite
     private
 
     def build_action(*args)
-      action_class.using(self.class.proxy_context).new(*args)
+      action_class.with(self.class.proxy_context).new(*args)
     end
   end
 end

--- a/spec/lib/granite/action/performer_spec.rb
+++ b/spec/lib/granite/action/performer_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe Granite::Action::Performer do
 
   describe '#ctx' do
     specify { expect(Action.new.ctx).to be_nil }
-    specify { expect(Action.using(performer: :value).new.ctx).to have_attributes(performer: :value) }
+    specify { expect(Action.with(performer: :value).new.ctx).to have_attributes(performer: :value) }
     specify { expect(Action.as(performer1).new.ctx).to have_attributes(performer: performer1) }
 
     specify 'proxy works for deeper initialization' do
-      expect(Action.using(performer: :value).batch(2).map(&:ctx))
+      expect(Action.with(performer: :value).batch(2).map(&:ctx))
         .to contain_exactly(have_attributes(performer: :value), have_attributes(performer: :value))
     end
   end

--- a/spec/lib/granite/context_proxy_spec.rb
+++ b/spec/lib/granite/context_proxy_spec.rb
@@ -14,17 +14,17 @@ RSpec.describe Granite::ContextProxy do
     end
   end
   let(:performer) { performers.first }
-  let(:performers) { 2.times.map { instance_double(User) } }
+  let(:performers) { 10.times.map { |i| instance_double(User, "Performer #{i}") } }
   let(:context) { {performer: performer} }
   let(:proxy) { instance_double(Granite::ContextProxy::Proxy) }
 
-  describe '.using' do
+  describe '.with' do
     before do
       allow(Granite::ContextProxy::Proxy).to receive(:new).with(klass, have_attributes(**context)) { proxy }
     end
 
     specify do
-      expect(klass.using(context)).to eq proxy
+      expect(klass.with(context)).to eq proxy
     end
   end
 
@@ -58,21 +58,6 @@ RSpec.describe Granite::ContextProxy do
         end
         expect(klass.proxy_context).to eq context
       end
-    end
-
-    it 'keeps context in thread safe way' do
-      thread_performers = []
-      threads = 2.times.map do |i|
-        Thread.new do
-          klass.with_context(performer: performers[i]) do
-            Thread.stop
-            thread_performers << klass.proxy_context[:performer]
-          end
-        end
-      end
-      sleep 0.01 until threads.all?(&:stop?)
-      threads.each { |thread| thread.run.join }
-      expect(thread_performers).to eq(performers)
     end
   end
 

--- a/spec/lib/granite/projector_spec.rb
+++ b/spec/lib/granite/projector_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Granite::Projector do
     stub_class(:descendant, Projector)
   end
 
-  describe '.using' do
+  describe '.with' do
     let(:context) { {performer: instance_double(Student)} }
-    specify { expect(Projector.using(context).new.action.ctx).to have_attributes(**context) }
+    specify { expect(Projector.with(context).new.action.ctx).to have_attributes(**context) }
   end
 
   describe '.controller_class' do


### PR DESCRIPTION
Since `Module.using` exists it would be better to rename it to something else.

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
