### PR TITLE
Fix ActiveRecord::Enum handling with represents

### DIFF
--- a/lib/granite/represents/attribute.rb
+++ b/lib/granite/represents/attribute.rb
@@ -1,6 +1,10 @@
 module Granite
   module Represents
     class Attribute < ActiveData::Model::Attributes::Attribute
+      types = {}
+      types[ActiveRecord::Enum::EnumType] = String if defined?(ActiveRecord)
+      TYPES = types.freeze
+
       delegate :writer, :reader, :reader_before_type_cast, to: :reflection
 
       def initialize(*_args)
@@ -84,6 +88,7 @@ module Granite
 
         attribute_type = reference.type_for_attribute(name.to_s)
 
+        return TYPES[attribute_type.class] if TYPES.key?(attribute_type.class)
         return Granite::Action::Types::Collection.new(convert_type_to_value_class(attribute_type.subtype)) if attribute_type.respond_to?(:subtype)
 
         convert_type_to_value_class(attribute_type)

--- a/spec/lib/granite/action/precondition_spec.rb
+++ b/spec/lib/granite/action/precondition_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Granite::Action::Precondition do
       description 'Test description'
 
       def call(expected_title:, **)
-        expected_title == title
+        respond_to_missing?(:title) && expected_title == title
       end
     end
 

--- a/spec/lib/granite/context_proxy_spec.rb
+++ b/spec/lib/granite/context_proxy_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe Granite::ContextProxy do
   let(:klass) do
     Class.new do
       include Granite::ContextProxy
-
-      def self.hash
-        'hash'
-      end
     end
   end
   let(:performer) { performers.first }

--- a/spec/lib/granite/represents/attribute_spec.rb
+++ b/spec/lib/granite/represents/attribute_spec.rb
@@ -242,6 +242,20 @@ RSpec.describe Granite::Represents::Attribute do
           expect(subject.type.subtype).to eq Integer
         end
       end
+
+      context 'with enum' do
+        before do
+          if ActiveRecord.gem_version >= Gem::Version.new('7.0')
+            DummyUser.enum :sign_in_count, once: 1, many: 2
+          else
+            DummyUser.enum sign_in_count: %i[once many]
+          end
+        end
+
+        specify do
+          expect(subject.type).to eq String
+        end
+      end
     end
 
     context 'when not defined' do


### PR DESCRIPTION
Given

```ruby
create_table :users, force: :cascade do |t|
  t.integer :sign_in_count
end

class User < ActiveRecord::Base
  enum :sign_in_count, zero: 0, one: 1, many: 2
end

class MyAction < Granite::Action
  subject :user
  represents :sign_in_count, of: :user
end

action = MyAction.new user, sign_in_count: 'many'
action.validate!
```

Before this PR:
```ruby
action.sign_in_count #=> nil
action.subject.sign_in_count #=> nil
```

After this PR:
```ruby
action.sign_in_count #=> "many"
action.subject.sign_in_count #=> "many"
```

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
