### PR TITLE
[ROGUE-3303] Fix broken typecasting for enums in AR 6.1

### DIFF
--- a/lib/granite/represents/attribute.rb
+++ b/lib/granite/represents/attribute.rb
@@ -84,7 +84,11 @@ module Granite
 
         attribute_type = reference.type_for_attribute(name.to_s)
 
-        return Granite::Action::Types::Collection.new(convert_type_to_value_class(attribute_type.subtype)) if attribute_type.respond_to?(:subtype)
+        # [ROGUE-3303] in ActiveRecord 6.1 `subtype` on `ActiveRecord::Enum::EnumType`
+        # changed visibility from private to public, which began to break typecasting
+        if attribute_type.respond_to?(:subtype) && !attribute_type.is_a?(ActiveRecord::Enum::EnumType)
+          return Granite::Action::Types::Collection.new(convert_type_to_value_class(attribute_type.subtype))
+        end
 
         convert_type_to_value_class(attribute_type)
       end


### PR DESCRIPTION
After upgrade to Rails 6.1 we have the following bug

```ruby
jft = JobFeaturedTalent.last
performer = jft.job.client.main_representative
action = BA::Job::FeaturedTalent::AddReaction.as(performer).new(JobFeaturedTalent.last, client_reaction: 'liked')
action.client_reaction
=> nil
```
this breaks ` rspec spec/apq/actions/ba/job/featured_talent/add_reaction_spec.rb:44` in platform
Happens because `:subtype` method changed its visibility from `private` to `public`, and returns a collection

This is very targeted change to just fix that spec, and maybe it should be rewritten better, but at least now it matches the previous behaviour for this specific case: `action.attribute('client_reaction').type` returns `String` with this code, as before
### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
