### PR TITLE
[SCX-326] Add Granite::Action::subject? helper method

### DIFF
--- a/lib/granite/action/subject.rb
+++ b/lib/granite/action/subject.rb
@@ -41,7 +41,7 @@ module Granite
           return
         end
 
-        reflection = self.class.reflect_on_association(self.class._subject)
+        reflection = find_subject_reflection
         attributes = extract_initialize_attributes(args)
 
         subject_attributes = extract_subject_attributes!(attributes, reflection)
@@ -51,6 +51,10 @@ module Granite
       end
 
       private
+
+      def find_subject_reflection
+        self.class.reflect_on_association(self.class._subject)
+      end
 
       def extract_initialize_attributes(args)
         if args.last.respond_to?(:to_unsafe_hash)

--- a/lib/granite/action/subject.rb
+++ b/lib/granite/action/subject.rb
@@ -33,12 +33,16 @@ module Granite
         def subject?
           _subject.present?
         end
+
+        def subject_reflection
+          reflect_on_association(_subject)
+        end
       end
 
       def initialize(*args)
         return super unless self.class.subject? # rubocop:disable Lint/ReturnInVoidContext
 
-        reflection = find_subject_reflection
+        reflection = self.class.subject_reflection
         attributes = extract_initialize_attributes(args)
 
         subject_attributes = extract_subject_attributes!(attributes, reflection)
@@ -48,10 +52,6 @@ module Granite
       end
 
       private
-
-      def find_subject_reflection
-        self.class.reflect_on_association(self.class._subject)
-      end
 
       def extract_initialize_attributes(args)
         if args.last.respond_to?(:to_unsafe_hash)

--- a/lib/granite/action/subject.rb
+++ b/lib/granite/action/subject.rb
@@ -29,10 +29,14 @@ module Granite
 
           self._subject = name
         end
+
+        def subject?
+          _subject.present?
+        end
       end
 
       def initialize(*args)
-        if self.class._subject.blank?
+        unless self.class.subject?
           super
           return
         end

--- a/lib/granite/action/subject.rb
+++ b/lib/granite/action/subject.rb
@@ -36,10 +36,7 @@ module Granite
       end
 
       def initialize(*args)
-        unless self.class.subject?
-          super
-          return
-        end
+        return super unless self.class.subject? # rubocop:disable Lint/ReturnInVoidContext
 
         reflection = find_subject_reflection
         attributes = extract_initialize_attributes(args)

--- a/spec/lib/granite/action/subject_spec.rb
+++ b/spec/lib/granite/action/subject_spec.rb
@@ -36,14 +36,12 @@ RSpec.describe Granite::Action::Subject do
   describe '.subject?' do
     before { stub_class(:action, Granite::Action) }
 
+    specify { expect(Action).not_to be_subject }
+
     context 'when action defines subject' do
       before { Action.subject(:student) }
 
       specify { expect(Action).to be_subject }
-    end
-
-    context 'when action does not define subject' do
-      specify { expect(Action).not_to be_subject }
     end
   end
 end

--- a/spec/lib/granite/action/subject_spec.rb
+++ b/spec/lib/granite/action/subject_spec.rb
@@ -1,15 +1,15 @@
 RSpec.describe Granite::Action::Subject do
-  before do
-    stub_class(:action, Granite::Action) do
-      subject :student
-      attribute :comment, String
-    end
-  end
-
   let(:student) { Student.create! }
   let(:teacher) { Teacher.create! }
 
   describe '#initialize' do
+    before do
+      stub_class(:action, Granite::Action) do
+        subject :student
+        attribute :comment, String
+      end
+    end
+
     specify { expect { Action.new(comment: 'Comment') }.to raise_error Granite::Action::SubjectNotFoundError }
     specify { expect(Action.new(comment: 'Comment', subject: student).student).to eq(student) }
 
@@ -33,16 +33,16 @@ RSpec.describe Granite::Action::Subject do
     specify { expect(Action.new(student, comment: 'Comment').comment).to eq('Comment') }
   end
 
-  describe '::subject?' do
-    specify { expect(Action).to be_subject }
+  describe '.subject?' do
+    before { stub_class(:action, Granite::Action) }
 
-    context 'when Action does not define subject' do
-      before do
-        stub_class(:action, Granite::Action) do
-          attribute :comment, String
-        end
-      end
+    context 'when action defines subject' do
+      before { Action.subject(:student) }
 
+      specify { expect(Action).to be_subject }
+    end
+
+    context 'when action does not define subject' do
       specify { expect(Action).not_to be_subject }
     end
   end

--- a/spec/lib/granite/action/subject_spec.rb
+++ b/spec/lib/granite/action/subject_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Granite::Action::Subject do
   end
 
   describe '::subject?' do
-    specify { expect(Action.subject?).to be_truthy }
+    specify { expect(Action).to be_subject }
 
     context 'when Action does not define subject' do
       before do
@@ -43,7 +43,7 @@ RSpec.describe Granite::Action::Subject do
         end
       end
 
-      specify { expect(Action.subject?).to be_falsey }
+      specify { expect(Action).not_to be_subject }
     end
   end
 end

--- a/spec/lib/granite/action/subject_spec.rb
+++ b/spec/lib/granite/action/subject_spec.rb
@@ -32,4 +32,18 @@ RSpec.describe Granite::Action::Subject do
     specify { expect(Action.new(comment: 'Comment', subject: student).comment).to eq('Comment') }
     specify { expect(Action.new(student, comment: 'Comment').comment).to eq('Comment') }
   end
+
+  describe '::subject?' do
+    specify { expect(Action.subject?).to be_truthy }
+
+    context 'when Action does not define subject' do
+      before do
+        stub_class(:action, Granite::Action) do
+          attribute :comment, String
+        end
+      end
+
+      specify { expect(Action.subject?).to be_falsey }
+    end
+  end
 end


### PR DESCRIPTION
This PR responds to the following need:
> I wish there was an easy way to check if a given action defines a `subject` or not, without having to look into the class internals.
```ruby
# before
Action._subject.blank?
# after
Action.subject?
```

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
