### PR TITLE
Fix represents does not work with alias attribute

### DIFF
--- a/gemfiles/.bundle/config
+++ b/gemfiles/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_RETRY: "1"

--- a/gemfiles/.bundle/config
+++ b/gemfiles/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_RETRY: "1"

--- a/lib/granite/represents/attribute.rb
+++ b/lib/granite/represents/attribute.rb
@@ -86,12 +86,18 @@ module Granite
       def type_from_type_for_attribute
         return nil unless reference.respond_to?(:type_for_attribute)
 
-        attribute_type = reference.type_for_attribute(name.to_s)
+        attribute_type = reference.type_for_attribute(attribute_name.to_s)
 
         return TYPES[attribute_type.class] if TYPES.key?(attribute_type.class)
         return Granite::Action::Types::Collection.new(convert_type_to_value_class(attribute_type.subtype)) if attribute_type.respond_to?(:subtype)
 
         convert_type_to_value_class(attribute_type)
+      end
+
+      def attribute_name
+        return name if ActiveModel.version >= Gem::Version.new('6.1.0')
+
+        reference.class.attribute_aliases[name.to_s] || name
       end
 
       def convert_type_to_value_class(attribute_type)

--- a/spec/lib/granite/represents/attribute_spec.rb
+++ b/spec/lib/granite/represents/attribute_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Granite::Represents::Attribute do
     end
 
     context 'when represented an aliased attribute' do
+      subject { action.attribute(:sign_ins) }
       before do
         stub_class(:action, Granite::Action) do
           allow_if { true }
@@ -78,8 +79,6 @@ RSpec.describe Granite::Represents::Attribute do
           end
         end
       end
-
-      subject { action.attribute(:sign_ins) }
 
       it 'sets default value' do
         expect(subject.read).to eq(1)

--- a/spec/lib/granite/represents/attribute_spec.rb
+++ b/spec/lib/granite/represents/attribute_spec.rb
@@ -65,6 +65,34 @@ RSpec.describe Granite::Represents::Attribute do
         end
       end
     end
+
+    context 'when represented an aliased attribute' do
+      before do
+        stub_class(:action, Granite::Action) do
+          allow_if { true }
+
+          represents :sign_ins, default: '1', of: :user
+
+          def user
+            @user ||= User.new
+          end
+        end
+      end
+
+      subject { action.attribute(:sign_ins) }
+
+      it 'sets default value' do
+        expect(subject.read).to eq(1)
+      end
+
+      it 'sets default value_before_type_cast' do
+        expect(subject.read_before_type_cast).to eq('1')
+      end
+
+      it 'returns correct type' do
+        expect(subject.type).to eq(Integer)
+      end
+    end
   end
 
   describe '#sync' do

--- a/spec/support/models/user.rb
+++ b/spec/support/models/user.rb
@@ -1,4 +1,5 @@
 require_relative 'application_record'
 
 class User < ApplicationRecord
+  alias_attribute :sign_ins, :sign_in_count
 end


### PR DESCRIPTION
https://github.com/toptal/granite/issues/81 

This PR is for fixing the issue ☝️ , the problem is `type_for_attribute` on AR <= 6.1  does not use `attribute_aliases` to determine the original field name because of that we weren't able to determine the correct field type.

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [X] All tests are passing.
- [X] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [X] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [X] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [X] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [X] Squash related commits together.
