### PR TITLE
[COR-941] Remove BA prefix from Granite generator

### DIFF
--- a/lib/generators/granite_generator.rb
+++ b/lib/generators/granite_generator.rb
@@ -5,11 +5,11 @@ class GraniteGenerator < Rails::Generators::NamedBase
   class_option :collection, type: :boolean, aliases: '-C', desc: 'Generate collection action'
 
   def create_action
-    template 'granite_action.rb.erb', "apq/actions/ba/#{file_path}.rb"
-    template 'granite_business_action.rb.erb', "apq/actions/ba/#{class_path.join('/')}/business_action.rb" unless options.collection?
+    template 'granite_action.rb.erb', "apq/actions/#{file_path}.rb"
+    template 'granite_business_action.rb.erb', "apq/actions/#{class_path.join('/')}/business_action.rb" unless options.collection?
     template 'granite_base_action.rb.erb', 'apq/actions/base_action.rb', skip: true
-    template 'granite_action_spec.rb.erb', "spec/apq/actions/ba/#{file_path}_spec.rb"
-    empty_directory "apq/actions/ba/#{file_path}/#{projector}" if projector
+    template 'granite_action_spec.rb.erb', "spec/apq/actions/#{file_path}_spec.rb"
+    empty_directory "apq/actions/#{file_path}/#{projector}" if projector
   end
 
   private
@@ -18,7 +18,7 @@ class GraniteGenerator < Rails::Generators::NamedBase
     if options.collection?
       'BaseAction'
     else
-      "BA::#{class_path.join('/').camelize}::BusinessAction"
+      "#{class_path.join('/').camelize}::BusinessAction"
     end
   end
 

--- a/lib/generators/templates/granite_action.rb.erb
+++ b/lib/generators/templates/granite_action.rb.erb
@@ -1,4 +1,4 @@
-class BA::<%= class_name %> < <%= base_class_name %>
+class <%= class_name %> < <%= base_class_name %>
 <% if projector -%>
   projector :<%= projector %>
 

--- a/lib/generators/templates/granite_action_spec.rb.erb
+++ b/lib/generators/templates/granite_action_spec.rb.erb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe BA::<%= class_name %> do
+RSpec.describe <%= class_name %> do
 <% if options.collection? -%>
   subject(:action) { described_class.as(performer).new(attributes) }
 

--- a/lib/generators/templates/granite_business_action.rb.erb
+++ b/lib/generators/templates/granite_business_action.rb.erb
@@ -1,3 +1,3 @@
-class BA::<%= class_path.join('/').camelize %>::BusinessAction < BaseAction
+class <%= class_path.join('/').camelize %>::BusinessAction < BaseAction
   subject :<%= subject_name %>
 end

--- a/spec/fixtures/action_example.rb
+++ b/spec/fixtures/action_example.rb
@@ -1,4 +1,4 @@
-class BA::User::Create < BA::User::BusinessAction
+class User::Create < User::BusinessAction
   allow_if { false }
 
   precondition do

--- a/spec/fixtures/action_spec_example.rb
+++ b/spec/fixtures/action_spec_example.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe BA::User::Create do
+RSpec.describe User::Create do
   subject(:action) { described_class.as(performer).new(user, attributes) }
 
   let(:user) { User.new }

--- a/spec/fixtures/base_action_example.rb
+++ b/spec/fixtures/base_action_example.rb
@@ -1,3 +1,3 @@
-class BA::User::BusinessAction < BaseAction
+class User::BusinessAction < BaseAction
   subject :user
 end

--- a/spec/fixtures/collection_action_example.rb
+++ b/spec/fixtures/collection_action_example.rb
@@ -1,4 +1,4 @@
-class BA::User::Create < BaseAction
+class User::Create < BaseAction
   allow_if { false }
 
   precondition do

--- a/spec/fixtures/collection_action_spec_example.rb
+++ b/spec/fixtures/collection_action_spec_example.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe BA::User::Create do
+RSpec.describe User::Create do
   subject(:action) { described_class.as(performer).new(attributes) }
 
   let(:performer) { double }

--- a/spec/fixtures/simple_action_example.rb
+++ b/spec/fixtures/simple_action_example.rb
@@ -1,4 +1,4 @@
-class BA::User::Create < BA::User::BusinessAction
+class User::Create < User::BusinessAction
   projector :simple
 
   allow_if { false }

--- a/spec/lib/generators/granite_generator_spec.rb
+++ b/spec/lib/generators/granite_generator_spec.rb
@@ -25,28 +25,28 @@ RSpec.describe GraniteGenerator do
   end
 
   def entries
-    destination_path('apq/actions/ba/user/').entries.map(&:to_s) - %w[. ..]
+    destination_path('apq/actions/user/').entries.map(&:to_s) - %w[. ..]
   end
 
   specify do
     run_generator %w[user/create]
     expect(entries).to match_array(%w[create.rb business_action.rb])
-    expect_same_content('apq/actions/ba/user/business_action.rb', 'base_action')
-    expect_same_content('apq/actions/ba/user/create.rb', 'action')
-    expect_same_content('spec/apq/actions/ba/user/create_spec.rb', 'action_spec')
+    expect_same_content('apq/actions/user/business_action.rb', 'base_action')
+    expect_same_content('apq/actions/user/create.rb', 'action')
+    expect_same_content('spec/apq/actions/user/create_spec.rb', 'action_spec')
   end
 
   specify do
     run_generator %w[user/create -C]
     expect(entries).to match_array(%w[create.rb])
-    expect_same_content('apq/actions/ba/user/create.rb', 'collection_action')
-    expect_same_content('spec/apq/actions/ba/user/create_spec.rb', 'collection_action_spec')
+    expect_same_content('apq/actions/user/create.rb', 'collection_action')
+    expect_same_content('spec/apq/actions/user/create_spec.rb', 'collection_action_spec')
   end
 
   specify do
     run_generator %w[user/create simple]
     expect(entries).to match_array(%w[create create.rb business_action.rb])
-    expect(destination_path('apq/actions/ba/user/create/simple/')).to be_directory
-    expect_same_content('apq/actions/ba/user/create.rb', 'simple_action')
+    expect(destination_path('apq/actions/user/create/simple/')).to be_directory
+    expect_same_content('apq/actions/user/create.rb', 'simple_action')
   end
 end


### PR DESCRIPTION
Currently Granite action generator uses BA prefix when generating action. However this isn’t necessarily the best practice as different projects use different prefixes (or no prefix at all).

Describe the changes and motivations for the pull request.

### Review

- [na] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Squash related commits together.
