### PR TITLE
Update granite-form with removed lifecycle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# CI
-.github/workflows/ @toptal/coresmiths-team
+* @toptal/coresmiths-team

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ AllCops:
     - 'log/**/*'
   DisplayCopNames: true
   TargetRubyVersion: 2.6
+  TargetRailsVersion: 5.1
   NewCops: enable
 
 Naming/FileName:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # master (not released yet)
 
+* Remove `BA` prefix in granite action generator
+* Remove automatic synchronization from `embeds_many`/`embeds_one` associated objects (`action.association`) to their appropriate virtual attribute (`action.attributes('association')`)
+
 # Version 0.15.0
 
 * [BREAKING] Change form builder from ActiveData to Granite::Form. This means Granite no longer depends

--- a/granite.gemspec
+++ b/granite.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.5'
 
   s.add_runtime_dependency 'actionpack', '>= 5.1', '< 7.1'
-  s.add_runtime_dependency 'granite-form', '>= 0.2.0'
+  s.add_runtime_dependency 'granite-form', '>= 0.3.0'
   s.add_runtime_dependency 'activesupport', '>= 5.1', '< 7.1'
   s.add_runtime_dependency 'memoist', '~> 0.16'
   s.add_runtime_dependency 'ruby2_keywords', '~> 0.0.5'

--- a/lib/granite/action/performing.rb
+++ b/lib/granite/action/performing.rb
@@ -93,7 +93,6 @@ module Granite
 
       def perform_action(raise_errors: false, **options)
         result = run_callbacks(:execute_perform) do
-          apply_association_changes!
           execute_perform!(**options)
         end
         @_action_performed = true

--- a/lib/granite/base.rb
+++ b/lib/granite/base.rb
@@ -1,6 +1,5 @@
 require 'granite/form/model'
 require 'granite/form/model/primary'
-require 'granite/form/model/lifecycle'
 require 'granite/form/model/associations'
 
 require 'granite/translations'


### PR DESCRIPTION
* Update granite form
* Take ownership of whole repository
* Remove automatic synchronization from `embeds_many`/`embeds_one` associated objects (`action.association`) to their appropriate virtual attribute (`action.attributes('association')`)

### Review

- [x] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [x] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Squash related commits together.
