### PR TITLE
Implement assign_data ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Next
+
+* Allow ordering of `assign_data` blocks using `before` keyword.
+
 ## v0.15.1
 
 * Remove `BA` prefix in granite action generator

--- a/spec/lib/granite/assign_data_spec.rb
+++ b/spec/lib/granite/assign_data_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Granite::AssignData do
   subject(:action) { DummyAction.new(user) }
-  let!(:user) { User.create! }
+  let!(:user) { User.create!(full_name: '') }
 
   before do
     stub_class(:dummy_action, Granite::Action) do
@@ -30,6 +30,22 @@ RSpec.describe Granite::AssignData do
     end
 
     it { expect { action.validate }.to change { user.full_name }.to('New Name') }
+  end
+
+  context 'when using :before' do
+    before do
+      DummyAction.class_eval do
+        assign_data :add4
+        assign_data :add1, :add3, before: :add4
+        assign_data :add2, before: :add3
+
+        ('1'..'4').each do |i|
+          define_method("add#{i}") { user.full_name += i }
+        end
+      end
+    end
+
+    it { expect { action.validate }.to change { user.full_name }.to('1234') }
   end
 
   context 'when using method name & options' do


### PR DESCRIPTION
Allows ordering of `assign_data` blocks/methods using `before` keyword. This is mostly needed since https://github.com/toptal/granite/pull/92 means syncing represented attributes is no longer done one by one but instead is done in batches. This means that developers don't have any means to make their own `assign_data` blocks run before `sync_attributes` which is important in some cases.

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
