### PR TITLE
Add after_initialize callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Next
+
+* Add `after_initialize` callback 
+
 ## v0.15.1
 
 * Remove `BA` prefix in granite action generator

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,27 @@ end
 
 ### Callbacks
 
+
+#### `after_initialize`
+
+is triggered after an action is initialized.
+
+```ruby
+class Action < Granite::Action
+  attribute :name, String
+
+  after_initialize do
+    self.name = 'Default'
+  end
+
+  # OR
+  # after_initialize :method_to_trigger
+end
+
+Action.new.name
+# => 'Default'
+```
+
 #### `after_commit`
 
 is triggered after DB transaction committed.

--- a/lib/granite/action.rb
+++ b/lib/granite/action.rb
@@ -63,6 +63,13 @@ module Granite
       merge_errors(e.action.errors)
     end
 
+    define_model_callbacks :initialize, only: :after
+
+    def initialize(*)
+      super
+      _run_initialize_callbacks
+    end
+
     if ActiveModel.version < Gem::Version.new('6.1.0')
       def merge_errors(other_errors)
         errors.messages.deep_merge!(other_errors.messages) do |_, this, other|

--- a/lib/granite/base.rb
+++ b/lib/granite/base.rb
@@ -11,8 +11,8 @@ module Granite
   # embeds_many)
   module Base
     extend ActiveSupport::Concern
+    extend ActiveModel::Callbacks
 
-    include ActiveSupport::Callbacks
     include Granite::Form::Model
     include Granite::Form::Model::Representation
     include Granite::Form::Model::Dirty

--- a/spec/lib/granite/action_spec.rb
+++ b/spec/lib/granite/action_spec.rb
@@ -116,6 +116,19 @@ RSpec.describe Granite::Action do
     end
   end
 
+  describe '.after_initialize' do
+    subject { Action.new.callbacks }
+
+    before do
+      stub_class :Action, Granite::Action do
+        collection :callbacks, String
+        after_initialize { callbacks << 'after_initialize' }
+      end
+    end
+
+    it { is_expected.to eq(%w[after_initialize]) }
+  end
+
   describe '#performable?' do
     before { Action.precondition { decline_with(:message) unless comment == 'Comment' } }
 


### PR DESCRIPTION
In some cases we need to run some complex logic after action is initialized. While it can be achieved by overriding `def initialize`, a nicer way is to provide `after_initialize` callback.

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
