### PR TITLE
Fix after_commit running even if action is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
-* Add `after_initialize` callback 
+* Add `after_initialize` callback
+* Fix `after_commit` being called even if `perform` fails (because of failing preconditions/validations)
 
 ## v0.15.1
 

--- a/lib/granite/action/performing.rb
+++ b/lib/granite/action/performing.rb
@@ -42,7 +42,9 @@ module Granite
       # @return [Object] result of execute_perform! method execution or false in case of errors
       def perform(context: nil, **options)
         transaction do
-          valid?(context) && perform_action(**options)
+          fail Rollback unless valid?(context)
+
+          perform_action(**options)
         end
       end
 

--- a/spec/lib/granite/action/transaction_spec.rb
+++ b/spec/lib/granite/action/transaction_spec.rb
@@ -57,6 +57,21 @@ RSpec.describe Granite::Action::Transaction do
       end
     end
 
+    context 'when preconditions fail' do
+      before do
+        Action.precondition { decline_with(:invalid) }
+      end
+
+      it { expect { perform }.to not_change { action.callbacks }.and raise_error(Granite::Action::ValidationError) }
+
+      context 'when using perform' do
+        subject(:perform) { action.perform }
+
+        it { expect(perform).to be(false) }
+        it { expect { perform }.to not_change { action.callbacks } }
+      end
+    end
+
     context 'when actions chained with after_commit' do
       let(:sub_action) { SubAction.new }
 


### PR DESCRIPTION
`after_commit` runs when using `perform` even if preconditions or validations fail. This fixes that by explicitly rolling back the transaction when `perform` fails because of preconditions/validations.

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
