### PR TITLE
Remove capybara from dev deps

### DIFF
--- a/granite.gemspec
+++ b/granite.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'activerecord'
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'bump'
-  s.add_development_dependency 'capybara', '~> 2.18'
   s.add_development_dependency 'fuubar', '~> 2.0'
   s.add_development_dependency 'pg', '< 2'
   s.add_development_dependency 'pry-byebug'


### PR DESCRIPTION
Dependabot tries to update capybara #108 but the previous attempts were closed (#30, #32, #33, #34, #35). Today, it seems that the capybara gem is not used anymore in the repository so it's better to remove it just to not bother with the updates in the future.

### Review

- [x] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Squash related commits together.
