### PR TITLE
[DEVX-2655] Fix in_transaction collisions with other gems

### DIFF
--- a/lib/granite/action/transaction.rb
+++ b/lib/granite/action/transaction.rb
@@ -24,10 +24,10 @@ module Granite
 
       private
 
-      attr_accessor :in_transaction
+      attr_accessor :granite_in_transaction
 
       def transaction(&block)
-        if in_transaction
+        if granite_in_transaction
           yield
         else
           run_in_transaction(&block)
@@ -35,14 +35,14 @@ module Granite
       end
 
       def run_in_transaction
-        self.in_transaction = true
+        self.granite_in_transaction = true
 
         TransactionManager.transaction do
           TransactionManager.after_commit(self)
           yield
         end
       ensure
-        self.in_transaction = false
+        self.granite_in_transaction = false
       end
     end
   end

--- a/spec/lib/granite/action/transaction_spec.rb
+++ b/spec/lib/granite/action/transaction_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe Granite::Action::Transaction do
         end
 
         def execute_perform!(*)
+          # Simulates the after_commit_everywhere in_transaction helper (https://github.com/Envek/after_commit_everywhere/pull/23)
+          # to avoid name collisions
+          in_transaction { 'test' }
+        end
+
+        def in_transaction
+          yield
         end
       end
     end


### PR DESCRIPTION
There is a name collision for the `in_transaction` attribute/method in [granite](https://github.com/toptal/granite/blob/master/lib/granite/action/transaction.rb#L27) and [after_commit_everywhere](https://github.com/Envek/after_commit_everywhere/pull/23/files)

Changing the private attribute on granite to fix the issue.

### Review

- Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [x] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Squash related commits together.
