### PR TITLE
[DEVX-2655] [Backport 0.15.x] Fix in_transaction collisions with other gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 git_source(:toptal) { |repo| "https://github.com/toptal/#{repo}.git" }
 
+gem 'granite-form', '0.1.1'
+
 gemspec

--- a/lib/granite/action/transaction.rb
+++ b/lib/granite/action/transaction.rb
@@ -36,10 +36,10 @@ module Granite
 
       private
 
-      attr_accessor :in_transaction
+      attr_accessor :granite_in_transaction
 
       def transaction(&block)
-        if in_transaction
+        if granite_in_transaction
           yield
         else
           run_in_transaction(&block)
@@ -47,14 +47,14 @@ module Granite
       end
 
       def run_in_transaction
-        self.in_transaction = true
+        self.granite_in_transaction = true
 
         TransactionManager.transaction do
           TransactionManager.after_commit(self)
           yield
         end
       ensure
-        self.in_transaction = false
+        self.granite_in_transaction = false
       end
     end
   end

--- a/spec/lib/granite/action/transaction_spec.rb
+++ b/spec/lib/granite/action/transaction_spec.rb
@@ -11,6 +11,16 @@ RSpec.describe Granite::Action::Transaction do
         stub_class(:action, Granite::Action) do
           allow_if { true }
 
+          def execute_perform!(*)
+            # Simulates the after_commit_everywhere in_transaction helper (https://github.com/Envek/after_commit_everywhere/pull/23)
+            # to avoid name collisions
+            in_transaction { 'test' }
+          end
+
+          def in_transaction
+            yield
+          end
+
           after_commit do
             fail DummyError, 'Dummy exception'
           end


### PR DESCRIPTION
Same as https://github.com/toptal/granite/pull/112 but for version 0.15.x

### Review

- Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [x] Get approval.

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Squash related commits together.
