### PR TITLE
Stop preconditions from being executed twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## v0.17.3
+
+* Stopped preconditions from being executed twice on `#try_perform!`
+
 ## v0.17.2
 
 * Deprecate `Granite::Action#perform` in favor of using `Granite::Action#try_perform!`, as these 2 methods are basically identical. It will be removed in next major version. (https://github.com/toptal/granite/pull/117)

--- a/lib/granite/action/performing.rb
+++ b/lib/granite/action/performing.rb
@@ -79,7 +79,7 @@ module Granite
       # @raise [Granite::Action::ValidationError] Action or associated objects are invalid
       # @raise [NotImplementedError] execute_perform! method was not defined yet
       def try_perform!(context: nil, **options)
-        return unless satisfy_preconditions?
+        return unless satisfy_preconditions?(cache_result: true)
 
         transaction do
           validate!(context)

--- a/lib/granite/action/preconditions.rb
+++ b/lib/granite/action/preconditions.rb
@@ -85,16 +85,17 @@ module Granite
 
       def initialize(*)
         @failed_preconditions = []
+        @preconditions_run = nil
         super
       end
 
       # Check if all preconditions are satisfied
       #
       # @return [Boolean] wheter all preconditions are satisfied
-      def satisfy_preconditions?
+      def satisfy_preconditions?(cache_result: false)
         errors.clear
         failed_preconditions.clear
-        run_preconditions!
+        run_preconditions!(cache_result: cache_result)
       end
 
       # Adds passed error message and options to `errors` object
@@ -105,8 +106,9 @@ module Granite
 
       private
 
-      def run_preconditions!
-        _preconditions.execute! self
+      def run_preconditions!(cache_result: false)
+        _preconditions.execute!(self) if @preconditions_run.nil?
+        @preconditions_run = true if cache_result
         errors.empty?
       end
 

--- a/lib/granite/version.rb
+++ b/lib/granite/version.rb
@@ -1,3 +1,3 @@
 module Granite
-  VERSION = '0.17.2'.freeze
+  VERSION = '0.17.3'.freeze
 end

--- a/spec/lib/granite/action/performing_spec.rb
+++ b/spec/lib/granite/action/performing_spec.rb
@@ -322,6 +322,37 @@ RSpec.describe Granite::Action::Performing do
   end
 
   describe '#try_perform!' do
+    context 'when checking preconditions run count' do
+      let(:action) { Action.new(user) }
+
+      before do
+        stub_class(:action, Granite::Action) do
+          subject :user, class_name: 'DummyUser'
+
+          allow_if { true }
+
+          attr_accessor :preconditions_run_count
+
+          precondition do
+            @preconditions_run_count ||= 0
+            @preconditions_run_count += 1
+          end
+
+          private
+
+          def execute_perform!(*)
+            false
+          end
+        end
+      end
+
+      it 'runs preconditions only once' do
+        action.try_perform!
+
+        expect(action.preconditions_run_count).to eq(1)
+      end
+    end
+
     context 'with login' do
       let(:action) { Action.new(user, login: 'Login') }
 


### PR DESCRIPTION
When running an action with `#try_perform!`, preconditions are being run twice. This PR fixes this.

https://github.com/toptal/platform/pull/78833 is a platform PR run against this patch, with successfull unit tests and features:

![Devx-1752-test-granite-by-lstrzebinczyk-·-Pull-Request-78833-·-toptal-platform](https://github.com/user-attachments/assets/1cd3a9aa-8461-4f81-8468-9b5c51cc01ae)
![Devx-1752-test-granite-by-lstrzebinczyk-·-Pull-Request-78833-·-toptal-platform(1)](https://github.com/user-attachments/assets/22b4d190-5f1f-46d4-ba3e-e040dcde27d9)


### How to test

- fetch platform branch of https://github.com/toptal/platform/pull/78833
- open console
- enter this class into console:
```
class TestAction < BaseAction 
  precondition do
    puts "RUNNING PRECONDITION"
  end

  subject :role_step
  
  history false

  private

  def execute_perform!(*)
  end
end
```
- run `TestAction.as_system.new(RoleStep.new).try_perform!`
- in your console, you should see `RUNNING PRECONDITION` twice
- run the same on master, you'll see it twice.

### Review

- [x] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [x] All tests are passing.
- [x] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
