### PR TITLE
[DEVX-5035] Add DevX label to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
       - "ruby"
       - "dependencies"
       - "WIP"
+      - "DevX"
     reviewers:
       - "toptal/devx"
     registries:
@@ -57,6 +58,7 @@ updates:
       - "dependencies"
       - "gha"
       - "WIP"
+      - "DevX"
     reviewers:
       - "toptal/devx"
     open-pull-requests-limit: 10


### PR DESCRIPTION
https://toptal-core.atlassian.net/browse/DEVX-5035

This PR adds DevX label to PRs created by dependabot. This simplifies handling of them (it's easier to keep them visible in Seal).

https://github.com/toptal/granite/labels/DevX is present