### PR TITLE
Missing plugin_class_name in RuboCop config example is added

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Add this to your Rubocop config file:
 plugins:
   - granite:
       require_path: rubocop-granite
+      plugin_class_name: RuboCop::Granite::Plugin
 ```
 
 The plugin system requires RuboCop 1.72+. For earlier versions, use `require: rubocop-granite` instead.


### PR DESCRIPTION
The RuboCop plugin configuration example in the README was missing
the `plugin_class_name` option, which is required for the plugin
system to work correctly.

### Review

- [ ] Document code according to [Getting Started with Yard](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md).
- [ ] All tests are passing.
- [ ] Test manually.
- [ ] Get approval.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.